### PR TITLE
Save the VirtualAddressSpace in the BackendAllocator.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1754,6 +1754,7 @@ filegroup(
         "src/heap/mutable-page-metadata-inl.h",
         "src/heap/memory-chunk.cc",
         "src/heap/memory-chunk.h",
+        "src/heap/memory-chunk-constants.h",
         "src/heap/memory-chunk-inl.h",
         "src/heap/memory-chunk-layout.cc",
         "src/heap/memory-chunk-layout.h",

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -699,9 +699,6 @@ assert(!v8_enable_external_code_space || v8_enable_pointer_compression,
 assert(!v8_enable_pointer_compression_8gb || v8_enable_pointer_compression,
        "Pointer compression for 8GB cages requires pointer compression")
 
-assert(!v8_enable_sandbox || v8_enable_pointer_compression_shared_cage,
-       "The sandbox requires the shared pointer compression cage")
-
 assert(!v8_enable_sandbox || v8_enable_external_code_space,
        "The sandbox requires the external code space")
 

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -3832,6 +3832,7 @@ v8_header_set("v8_internal_headers") {
     "src/heap/marking.h",
     "src/heap/memory-allocator.h",
     "src/heap/memory-balancer.h",
+    "src/heap/memory-chunk-constants.h",
     "src/heap/memory-chunk-inl.h",
     "src/heap/memory-chunk-layout.h",
     "src/heap/memory-chunk-metadata-inl.h",

--- a/include/v8-internal.h
+++ b/include/v8-internal.h
@@ -48,6 +48,8 @@ class LocalHeap;
 class Isolate;
 class IsolateGroup;
 class LocalIsolate;
+class IsolateGroup;
+class Sandbox;
 
 typedef uintptr_t Address;
 static constexpr Address kNullAddress = 0;

--- a/include/v8-internal.h
+++ b/include/v8-internal.h
@@ -46,6 +46,7 @@ namespace internal {
 class Heap;
 class LocalHeap;
 class Isolate;
+class IsolateGroup;
 class LocalIsolate;
 
 typedef uintptr_t Address;

--- a/include/v8-isolate.h
+++ b/include/v8-isolate.h
@@ -202,6 +202,70 @@ enum class MemoryPressureLevel { kNone, kModerate, kCritical };
 using StackState = cppgc::EmbedderStackState;
 
 /**
+ * The set of V8 isolates in a process is partitioned into groups.  Each group
+ * has its own sandbox (if V8 was configured with support for the sandbox) and
+ * pointer-compression cage (if configured with pointer compression).
+ *
+ * By default, all isolates are placed in the same group.  This is the most
+ * efficient configuration in terms of speed and memory use.  However, with
+ * pointer compression enabled, total heap usage of isolates in a group cannot
+ * cannot exceed 4 GB, not counting array buffers and other off-heap storage.
+ * Using multiple isolate groups can allow embedders to allocate more than 4GB
+ * of objects with pointer compression enabled, if the embedder's use case can
+ * span multiple isolates.
+ *
+ * Creating an isolate group reserves a range of virtual memory addresses.  A
+ * group's memory mapping will be released when the last isolate in the group is
+ * disposed, and there are no more live IsolateGroup objects that refer to it.
+ *
+ * Note that V8 does not currently support multiple sandboxes; isolate groups
+ * are currently useful mainly in a configuration with pointer compression but
+ * without the sandbox.
+ */
+class V8_EXPORT IsolateGroup {
+ public:
+  /**
+   * Get the default isolate group.  If this V8's build configuration only
+   * supports a single group, as is the case when the sandbox is enabled, this
+   * is a reference to that single group.  Otherwise this is a group like any
+   * other, distinguished only in that it is the first group.
+   */
+  static IsolateGroup GetDefault();
+
+  /**
+   * Return true if new isolate groups can be created at run-time, or false if
+   * all isolates must be in the same group.
+   */
+  static constexpr bool CanCreateNewGroups() {
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+    return true;
+#else
+    return false;
+#endif
+  }
+
+  /**
+   * Create a new isolate group.  If this V8's build configuration only supports
+   * a single group, abort.
+   */
+  static IsolateGroup Create();
+
+  IsolateGroup(const IsolateGroup&);
+  IsolateGroup& operator=(const IsolateGroup&);
+  ~IsolateGroup();
+
+  bool operator==(const IsolateGroup& other) const {
+    return isolate_group_ == other.isolate_group_;
+  }
+
+ private:
+  friend class Isolate;
+  explicit IsolateGroup(internal::IsolateGroup* isolate_group);
+
+  internal::IsolateGroup* isolate_group_;
+};
+
+/**
  * Isolate represents an isolated instance of the V8 engine.  V8 isolates have
  * completely separate states.  Objects from one isolate must not be used in
  * other isolates.  The embedder can create multiple isolates and use them in
@@ -589,9 +653,9 @@ class V8_EXPORT Isolate {
    * currently entered isolate.
    *
    * Only Isolate::GetData() and Isolate::SetData(), which access the
-   * embedder-controlled parts of the isolate, are allowed to be called on the
-   * uninitialized isolate. To initialize the isolate, call
-   * `Isolate::Initialize()` or initialize a `SnapshotCreator`.
+   * embedder-controlled parts of the isolate, as well as Isolate::GetGroup(),
+   * are allowed to be called on the uninitialized isolate. To initialize the
+   * isolate, call `Isolate::Initialize()` or initialize a `SnapshotCreator`.
    *
    * When an isolate is no longer used its resources should be freed
    * by calling Dispose().  Using the delete operator is not allowed.
@@ -599,6 +663,12 @@ class V8_EXPORT Isolate {
    * V8::Initialize() must have run prior to this.
    */
   static Isolate* Allocate();
+  static Isolate* Allocate(const IsolateGroup& group);
+
+  /**
+   * Return the group for this isolate.
+   */
+  IsolateGroup GetGroup() const;
 
   /**
    * Initialize an Isolate previously allocated by Isolate::Allocate().
@@ -615,6 +685,7 @@ class V8_EXPORT Isolate {
    * V8::Initialize() must have run prior to this.
    */
   static Isolate* New(const CreateParams& params);
+  static Isolate* New(const IsolateGroup& group, const CreateParams& params);
 
   /**
    * Returns the entered isolate for the current thread or NULL in

--- a/include/v8-isolate.h
+++ b/include/v8-isolate.h
@@ -202,6 +202,25 @@ enum class MemoryPressureLevel { kNone, kModerate, kCritical };
 using StackState = cppgc::EmbedderStackState;
 
 /**
+ * Each isolate group has its own sandbox
+ * (if V8 was configured with support for the sandbox) and
+ * pointer-compression cage (if configured with pointer compression).
+ *
+ */
+class V8_EXPORT Sandbox {
+ public:
+  bool operator==(const Sandbox& other) const {
+    return sandbox_ == other.sandbox_;
+  }
+
+ private:
+  friend class IsolateGroup;
+  explicit Sandbox(internal::Sandbox* sandbox);
+
+  internal::Sandbox* sandbox_;
+};
+
+/**
  * The set of V8 isolates in a process is partitioned into groups.  Each group
  * has its own sandbox (if V8 was configured with support for the sandbox) and
  * pointer-compression cage (if configured with pointer compression).
@@ -218,9 +237,6 @@ using StackState = cppgc::EmbedderStackState;
  * group's memory mapping will be released when the last isolate in the group is
  * disposed, and there are no more live IsolateGroup objects that refer to it.
  *
- * Note that V8 does not currently support multiple sandboxes; isolate groups
- * are currently useful mainly in a configuration with pointer compression but
- * without the sandbox.
  */
 class V8_EXPORT IsolateGroup {
  public:
@@ -253,6 +269,10 @@ class V8_EXPORT IsolateGroup {
   IsolateGroup(const IsolateGroup&);
   IsolateGroup& operator=(const IsolateGroup&);
   ~IsolateGroup();
+
+#ifdef V8_ENABLE_SANDBOX
+  Sandbox GetSandbox();
+#endif
 
   bool operator==(const IsolateGroup& other) const {
     return isolate_group_ == other.isolate_group_;

--- a/src/DEPS
+++ b/src/DEPS
@@ -16,6 +16,7 @@ include_rules = [
   "+src/compiler/wasm-compiler.h",
   "-src/flags/flags-impl.h",
   "-src/heap",
+  "+src/heap/memory-chunk-constants.h",
   "+src/heap/memory-chunk-metadata.h",
   "+src/heap/code-range.h",
   "+src/heap/read-only-spaces.h",

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -9864,14 +9864,12 @@ void Isolate::TerminateExecution() {
 
 bool Isolate::IsExecutionTerminating() {
   i::Isolate* i_isolate = reinterpret_cast<i::Isolate*>(this);
-#ifdef DEBUG
   // This method might be called on a thread that's not bound to any Isolate
   // and thus pointer compression schemes might have cage base value unset.
   // Read-only roots accessors contain type DCHECKs which require access to
   // V8 heap in order to check the object type. So, allow heap access here
   // to let the checks work.
   i::PtrComprCageAccessScope ptr_compr_cage_access_scope(i_isolate);
-#endif  // DEBUG
   return i_isolate->is_execution_terminating();
 }
 
@@ -10076,14 +10074,12 @@ void Isolate::Dispose() {
 
 void Isolate::DumpAndResetStats() {
   i::Isolate* i_isolate = reinterpret_cast<i::Isolate*>(this);
-#ifdef DEBUG
   // This method might be called on a thread that's not bound to any Isolate
   // and thus pointer compression schemes might have cage base value unset.
   // Read-only roots accessors contain type DCHECKs which require access to
   // V8 heap in order to check the object type. So, allow heap access here
   // to let the checks work.
   i::PtrComprCageAccessScope ptr_compr_cage_access_scope(i_isolate);
-#endif  // DEBUG
   i_isolate->DumpAndResetStats();
 }
 
@@ -10592,14 +10588,12 @@ void Isolate::LowMemoryNotification() {
     i::NestedTimedHistogramScope idle_notification_scope(
         i_isolate->counters()->gc_low_memory_notification());
     TRACE_EVENT0("v8", "V8.GCLowMemoryNotification");
-#ifdef DEBUG
     // This method might be called on a thread that's not bound to any Isolate
     // and thus pointer compression schemes might have cage base value unset.
     // Read-only roots accessors contain type DCHECKs which require access to
     // V8 heap in order to check the object type. So, allow heap access here
     // to let the checks work.
     i::PtrComprCageAccessScope ptr_compr_cage_access_scope(i_isolate);
-#endif  // DEBUG
     i_isolate->heap()->CollectAllAvailableGarbage(
         i::GarbageCollectionReason::kLowMemoryNotification);
   }

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -9649,6 +9649,10 @@ void Isolate::HandleExternalMemoryInterrupt() {
   heap->HandleExternalMemoryInterrupt();
 }
 
+Sandbox::Sandbox(i::Sandbox* sandbox) : sandbox_(sandbox) {
+  DCHECK_NOT_NULL(sandbox_);
+}
+
 IsolateGroup::IsolateGroup(i::IsolateGroup* isolate_group)
     : isolate_group_(isolate_group) {
   DCHECK_NOT_NULL(isolate_group_);
@@ -9672,12 +9676,19 @@ IsolateGroup& IsolateGroup::operator=(const IsolateGroup& other) {
   return *this;
 }
 
+#ifdef V8_ENABLE_SANDBOX
+Sandbox IsolateGroup::GetSandbox() {
+  return Sandbox(isolate_group_->sandbox());
+}
+#endif
+
 // static
 IsolateGroup IsolateGroup::GetDefault() {
   return IsolateGroup(i::IsolateGroup::AcquireDefault());
 }
 
-static_assert(IsolateGroup::CanCreateNewGroups() == i::IsolateGroup::CanCreateNewGroups());
+static_assert(IsolateGroup::CanCreateNewGroups() ==
+              i::IsolateGroup::CanCreateNewGroups());
 
 // static
 IsolateGroup IsolateGroup::Create() {

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -9649,6 +9649,41 @@ void Isolate::HandleExternalMemoryInterrupt() {
   heap->HandleExternalMemoryInterrupt();
 }
 
+IsolateGroup::IsolateGroup(i::IsolateGroup* isolate_group)
+    : isolate_group_(isolate_group) {
+  DCHECK_NOT_NULL(isolate_group_);
+}
+
+IsolateGroup::~IsolateGroup() {
+  DCHECK_NOT_NULL(isolate_group_);
+  isolate_group_->Release();
+#ifdef DEBUG
+  isolate_group_ = nullptr;
+#endif
+}
+
+IsolateGroup::IsolateGroup(const IsolateGroup& other)
+    : isolate_group_(other.isolate_group_->Acquire()) {}
+
+IsolateGroup& IsolateGroup::operator=(const IsolateGroup& other) {
+  i::IsolateGroup* other_group = other.isolate_group_->Acquire();
+  isolate_group_->Release();
+  isolate_group_ = other_group;
+  return *this;
+}
+
+// static
+IsolateGroup IsolateGroup::GetDefault() {
+  return IsolateGroup(i::IsolateGroup::AcquireDefault());
+}
+
+static_assert(IsolateGroup::CanCreateNewGroups() == i::IsolateGroup::CanCreateNewGroups());
+
+// static
+IsolateGroup IsolateGroup::Create() {
+  return IsolateGroup(i::IsolateGroup::New());
+}
+
 HeapProfiler* Isolate::GetHeapProfiler() {
   i::HeapProfiler* heap_profiler =
       reinterpret_cast<i::Isolate*>(this)->heap_profiler();
@@ -9892,7 +9927,18 @@ bool Isolate::IsCurrent() const {
 
 // static
 Isolate* Isolate::Allocate() {
-  return reinterpret_cast<Isolate*>(i::Isolate::New());
+  return Isolate::Allocate(IsolateGroup::GetDefault());
+}
+
+// static
+Isolate* Isolate::Allocate(const IsolateGroup& group) {
+  i::IsolateGroup* isolate_group = group.isolate_group_->Acquire();
+  return reinterpret_cast<Isolate*>(i::Isolate::New(isolate_group));
+}
+
+IsolateGroup Isolate::GetGroup() const {
+  const i::Isolate* i_isolate = reinterpret_cast<const i::Isolate*>(this);
+  return IsolateGroup(i_isolate->isolate_group()->Acquire());
 }
 
 Isolate::CreateParams::CreateParams() = default;
@@ -9998,7 +10044,12 @@ void Isolate::Initialize(Isolate* v8_isolate,
 }
 
 Isolate* Isolate::New(const Isolate::CreateParams& params) {
-  Isolate* v8_isolate = Allocate();
+  return Isolate::New(IsolateGroup::GetDefault(), params);
+}
+
+Isolate* Isolate::New(const IsolateGroup& group,
+                      const Isolate::CreateParams& params) {
+  Isolate* v8_isolate = Allocate(group);
   Initialize(v8_isolate, params);
   return v8_isolate;
 }

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -385,8 +385,8 @@ class ArrayBufferAllocator : public v8::ArrayBuffer::Allocator {
   class BackendAllocator {
    public:
     BackendAllocator() {
-      CHECK(i::GetProcessWideSandbox()->is_initialized());
-      VirtualAddressSpace* vas = i::GetProcessWideSandbox()->address_space();
+      CHECK(i::Sandbox::current()->is_initialized());
+      VirtualAddressSpace* vas = i::Sandbox::current()->address_space();
       constexpr size_t max_backing_memory_size = 8ULL * i::GB;
       constexpr size_t min_backing_memory_size = 1ULL * i::GB;
       size_t backing_memory_size = max_backing_memory_size;
@@ -415,7 +415,7 @@ class ArrayBufferAllocator : public v8::ArrayBuffer::Allocator {
       region_alloc_->set_on_merge_callback([this](i::Address start,
                                                   size_t size) {
         mutex_.AssertHeld();
-        VirtualAddressSpace* vas = i::GetProcessWideSandbox()->address_space();
+        VirtualAddressSpace* vas = i::Sandbox::current()->address_space();
         i::Address end = start + size;
         if (end == region_alloc_->end() &&
             start <= end_of_accessible_region_ - kChunkSize) {
@@ -444,8 +444,8 @@ class ArrayBufferAllocator : public v8::ArrayBuffer::Allocator {
     ~BackendAllocator() {
       // The sandbox may already have been torn down, in which case there's no
       // need to free any memory.
-      if (i::GetProcessWideSandbox()->is_initialized()) {
-        VirtualAddressSpace* vas = i::GetProcessWideSandbox()->address_space();
+      if (i::Sandbox::current()->is_initialized()) {
+        VirtualAddressSpace* vas = i::Sandbox::current()->address_space();
         vas->FreePages(region_alloc_->begin(), region_alloc_->size());
       }
     }
@@ -464,7 +464,7 @@ class ArrayBufferAllocator : public v8::ArrayBuffer::Allocator {
       i::Address end = region + length;
       size_t length_to_memset = length;
       if (end > end_of_accessible_region_) {
-        VirtualAddressSpace* vas = i::GetProcessWideSandbox()->address_space();
+        VirtualAddressSpace* vas = i::Sandbox::current()->address_space();
         i::Address new_end_of_accessible_region = RoundUp(end, kChunkSize);
         size_t size = new_end_of_accessible_region - end_of_accessible_region_;
         if (!vas->SetPagePermissions(end_of_accessible_region_, size,
@@ -6680,34 +6680,34 @@ const char* v8::V8::GetVersion() { return i::Version::GetVersion(); }
 
 #ifdef V8_ENABLE_SANDBOX
 VirtualAddressSpace* v8::V8::GetSandboxAddressSpace() {
-  Utils::ApiCheck(i::GetProcessWideSandbox()->is_initialized(),
+  Utils::ApiCheck(i::Sandbox::current()->is_initialized(),
                   "v8::V8::GetSandboxAddressSpace",
                   "The sandbox must be initialized first");
-  return i::GetProcessWideSandbox()->address_space();
+  return i::Sandbox::current()->address_space();
 }
 
 size_t v8::V8::GetSandboxSizeInBytes() {
-  Utils::ApiCheck(i::GetProcessWideSandbox()->is_initialized(),
+  Utils::ApiCheck(i::Sandbox::current()->is_initialized(),
                   "v8::V8::GetSandboxSizeInBytes",
                   "The sandbox must be initialized first.");
-  return i::GetProcessWideSandbox()->size();
+  return i::Sandbox::current()->size();
 }
 
 size_t v8::V8::GetSandboxReservationSizeInBytes() {
-  Utils::ApiCheck(i::GetProcessWideSandbox()->is_initialized(),
+  Utils::ApiCheck(i::Sandbox::current()->is_initialized(),
                   "v8::V8::GetSandboxReservationSizeInBytes",
                   "The sandbox must be initialized first");
-  return i::GetProcessWideSandbox()->reservation_size();
+  return i::Sandbox::current()->reservation_size();
 }
 
 bool v8::V8::IsSandboxConfiguredSecurely() {
-  Utils::ApiCheck(i::GetProcessWideSandbox()->is_initialized(),
+  Utils::ApiCheck(i::Sandbox::current()->is_initialized(),
                   "v8::V8::IsSandoxConfiguredSecurely",
                   "The sandbox must be initialized first");
   // The sandbox is (only) configured insecurely if it is a partially reserved
   // sandbox, since in that case unrelated memory mappings may end up inside
   // the sandbox address space where they could be corrupted by an attacker.
-  return !i::GetProcessWideSandbox()->is_partially_reserved();
+  return !i::Sandbox::current()->is_partially_reserved();
 }
 #endif  // V8_ENABLE_SANDBOX
 
@@ -9150,7 +9150,7 @@ std::unique_ptr<v8::BackingStore> v8::ArrayBuffer::NewBackingStore(
     void* deleter_data) {
   CHECK_LE(byte_length, i::JSArrayBuffer::kMaxByteLength);
 #ifdef V8_ENABLE_SANDBOX
-  Utils::ApiCheck(!data || i::GetProcessWideSandbox()->Contains(data),
+  Utils::ApiCheck(!data || i::Sandbox::current()->Contains(data),
                   "v8_ArrayBuffer_NewBackingStore",
                   "When the V8 Sandbox is enabled, ArrayBuffer backing stores "
                   "must be allocated inside the sandbox address space. Please "

--- a/src/codegen/code-stub-assembler.cc
+++ b/src/codegen/code-stub-assembler.cc
@@ -13567,8 +13567,9 @@ TNode<IntPtrT> CodeStubAssembler::PageMetadataFromMemoryChunk(
       ExternalReference::memory_chunk_metadata_table_address());
   TNode<Uint32T> index = Load<Uint32T>(
       address, IntPtrConstant(MemoryChunkLayout::kMetadataIndexOffset));
-  index = Word32And(
-      index, UniqueUint32Constant(MemoryChunk::kMetadataPointerTableSizeMask));
+  index = Word32And(index,
+                    UniqueUint32Constant(
+                        MemoryChunkConstants::kMetadataPointerTableSizeMask));
   TNode<IntPtrT> offset = ChangeInt32ToIntPtr(
       Word32Shl(index, UniqueUint32Constant(kSystemPointerSizeLog2)));
   TNode<IntPtrT> metadata = Load<IntPtrT>(table, offset);

--- a/src/codegen/external-reference.cc
+++ b/src/codegen/external-reference.cc
@@ -298,9 +298,8 @@ ExternalReference ExternalReference::sandbox_end_address() {
 }
 
 ExternalReference ExternalReference::empty_backing_store_buffer() {
-  return ExternalReference(Sandbox::current()
-                               ->constants()
-                               .empty_backing_store_buffer_address());
+  return ExternalReference(
+      Sandbox::current()->constants().empty_backing_store_buffer_address());
 }
 
 ExternalReference ExternalReference::external_pointer_table_address(

--- a/src/codegen/external-reference.cc
+++ b/src/codegen/external-reference.cc
@@ -342,7 +342,8 @@ ExternalReference ExternalReference::memory_chunk_metadata_table_address() {
 
 ExternalReference ExternalReference::js_dispatch_table_address() {
   // TODO(saelo): maybe rename to js_dispatch_table_base_address?
-  return ExternalReference(GetProcessWideJSDispatchTable()->base_address());
+  return ExternalReference(
+      IsolateGroup::current()->js_dispatch_table()->base_address());
 }
 
 #endif  // V8_ENABLE_SANDBOX

--- a/src/codegen/external-reference.cc
+++ b/src/codegen/external-reference.cc
@@ -290,15 +290,15 @@ ExternalReference ExternalReference::handle_scope_implementer_address(
 
 #ifdef V8_ENABLE_SANDBOX
 ExternalReference ExternalReference::sandbox_base_address() {
-  return ExternalReference(GetProcessWideSandbox()->base_address());
+  return ExternalReference(Sandbox::current()->base_address());
 }
 
 ExternalReference ExternalReference::sandbox_end_address() {
-  return ExternalReference(GetProcessWideSandbox()->end_address());
+  return ExternalReference(Sandbox::current()->end_address());
 }
 
 ExternalReference ExternalReference::empty_backing_store_buffer() {
-  return ExternalReference(GetProcessWideSandbox()
+  return ExternalReference(Sandbox::current()
                                ->constants()
                                .empty_backing_store_buffer_address());
 }

--- a/src/codegen/external-reference.h
+++ b/src/codegen/external-reference.h
@@ -465,13 +465,13 @@ enum class IsolateFieldId : uint8_t;
 #endif  // V8_INTL_SUPPORT
 
 #ifdef V8_ENABLE_SANDBOX
-#define EXTERNAL_REFERENCE_LIST_SANDBOX(V)                        \
-  V(sandbox_base_address, "Sandbox::base()")                      \
-  V(sandbox_end_address, "Sandbox::end()")                        \
-  V(empty_backing_store_buffer, "EmptyBackingStoreBuffer()")      \
-  V(code_pointer_table_address,                                   \
-    "IsolateGroup::current()->code_pointer_table()")              \
-  V(js_dispatch_table_address, "GetProcessWideJSDispatchTable()") \
+#define EXTERNAL_REFERENCE_LIST_SANDBOX(V)                                     \
+  V(sandbox_base_address, "Sandbox::base()")                                   \
+  V(sandbox_end_address, "Sandbox::end()")                                     \
+  V(empty_backing_store_buffer, "EmptyBackingStoreBuffer()")                   \
+  V(code_pointer_table_address,                                                \
+    "IsolateGroup::current()->code_pointer_table()")                           \
+  V(js_dispatch_table_address, "IsolateGroup::current()->js_dispatch_table()") \
   V(memory_chunk_metadata_table_address, "MemoryChunkMetadata::Table()")
 #else
 #define EXTERNAL_REFERENCE_LIST_SANDBOX(V)

--- a/src/codegen/x64/macro-assembler-x64.cc
+++ b/src/codegen/x64/macro-assembler-x64.cc
@@ -4569,7 +4569,8 @@ void MacroAssembler::CheckMarkBit(Register object, Register scratch0,
   MemoryChunkHeaderFromObject(object, scratch0);
 #ifdef V8_ENABLE_SANDBOX
   movl(scratch0, Operand(scratch0, MemoryChunkLayout::kMetadataIndexOffset));
-  andl(scratch0, Immediate(MemoryChunk::kMetadataPointerTableSizeMask));
+  andl(scratch0,
+       Immediate(MemoryChunkConstants::kMetadataPointerTableSizeMask));
   shll(scratch0, Immediate(kSystemPointerSizeLog2));
   LoadAddress(scratch1,
               ExternalReference::memory_chunk_metadata_table_address());

--- a/src/common/ptr-compr-inl.h
+++ b/src/common/ptr-compr-inl.h
@@ -343,14 +343,20 @@ PtrComprCageAccessScope::PtrComprCageAccessScope(Isolate* isolate)
 #ifdef V8_EXTERNAL_CODE_SPACE
       code_cage_base_(ExternalCodeCompressionScheme::base()),
 #endif  // V8_EXTERNAL_CODE_SPACE
-      saved_current_isolate_group_(IsolateGroup::current()),
-      saved_current_sandbox_(Sandbox::current()) {
+      saved_current_isolate_group_(IsolateGroup::current())
+#ifdef V8_ENABLE_SANDBOX
+      ,
+      saved_current_sandbox_(Sandbox::current())
+#endif
+{
   V8HeapCompressionScheme::InitBase(isolate->cage_base());
 #ifdef V8_EXTERNAL_CODE_SPACE
   ExternalCodeCompressionScheme::InitBase(isolate->code_cage_base());
 #endif  // V8_EXTERNAL_CODE_SPACE
   IsolateGroup::set_current(isolate->isolate_group());
+#ifdef V8_ENABLE_SANDBOX
   Sandbox::set_current(isolate->isolate_group()->sandbox());
+#endif  // V8_ENABLE_SANDBOX
 }
 
 PtrComprCageAccessScope::~PtrComprCageAccessScope() {
@@ -359,7 +365,9 @@ PtrComprCageAccessScope::~PtrComprCageAccessScope() {
   ExternalCodeCompressionScheme::InitBase(code_cage_base_);
 #endif  // V8_EXTERNAL_CODE_SPACE
   IsolateGroup::set_current(saved_current_isolate_group_);
+#ifdef V8_ENABLE_SANDBOX
   Sandbox::set_current(saved_current_sandbox_);
+#endif  // V8_ENABLE_SANDBOX
 }
 
 #endif  // V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES

--- a/src/common/ptr-compr-inl.h
+++ b/src/common/ptr-compr-inl.h
@@ -8,6 +8,7 @@
 #include "include/v8-internal.h"
 #include "src/execution/isolate.h"
 #include "src/execution/local-isolate-inl.h"
+#include "src/sandbox/sandbox.h"
 
 namespace v8 {
 namespace internal {
@@ -342,12 +343,14 @@ PtrComprCageAccessScope::PtrComprCageAccessScope(Isolate* isolate)
 #ifdef V8_EXTERNAL_CODE_SPACE
       code_cage_base_(ExternalCodeCompressionScheme::base()),
 #endif  // V8_EXTERNAL_CODE_SPACE
-      saved_current_isolate_group_(IsolateGroup::current()) {
+      saved_current_isolate_group_(IsolateGroup::current()),
+      saved_current_sandbox_(Sandbox::current()) {
   V8HeapCompressionScheme::InitBase(isolate->cage_base());
 #ifdef V8_EXTERNAL_CODE_SPACE
   ExternalCodeCompressionScheme::InitBase(isolate->code_cage_base());
 #endif  // V8_EXTERNAL_CODE_SPACE
   IsolateGroup::set_current(isolate->isolate_group());
+  Sandbox::set_current(isolate->isolate_group()->sandbox());
 }
 
 PtrComprCageAccessScope::~PtrComprCageAccessScope() {
@@ -356,6 +359,7 @@ PtrComprCageAccessScope::~PtrComprCageAccessScope() {
   ExternalCodeCompressionScheme::InitBase(code_cage_base_);
 #endif  // V8_EXTERNAL_CODE_SPACE
   IsolateGroup::set_current(saved_current_isolate_group_);
+  Sandbox::set_current(saved_current_sandbox_);
 }
 
 #endif  // V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES

--- a/src/common/ptr-compr.cc
+++ b/src/common/ptr-compr.cc
@@ -24,6 +24,12 @@ void MainCage::set_base_non_inlined(Address base) { base_ = base; }
 
 #ifdef V8_ENABLE_SANDBOX
 uintptr_t TrustedCage::base_ = kNullAddress;
+
+// static
+Address TrustedCage::base_non_inlined() { return base_; }
+
+// static
+void TrustedCage::set_base_non_inlined(Address base) { base_ = base; }
 #endif  // V8_ENABLE_SANDBOX
 
 #ifdef V8_EXTERNAL_CODE_SPACE

--- a/src/common/ptr-compr.h
+++ b/src/common/ptr-compr.h
@@ -78,8 +78,10 @@ using V8HeapCompressionScheme = V8HeapCompressionSchemeImpl<MainCage>;
 class TrustedCage : public AllStatic {
   friend class V8HeapCompressionSchemeImpl<TrustedCage>;
 
-  // The TrustedCage is only used in the shared cage build configuration, so
-  // there is no need for a thread_local version.
+  // Just to unify code with other cages in the multi-cage mode.
+  static V8_EXPORT_PRIVATE Address base_non_inlined();
+  static V8_EXPORT_PRIVATE void set_base_non_inlined(Address base);
+
   static V8_EXPORT_PRIVATE uintptr_t base_ V8_CONSTINIT;
 };
 using TrustedSpaceCompressionScheme = V8HeapCompressionSchemeImpl<TrustedCage>;

--- a/src/common/ptr-compr.h
+++ b/src/common/ptr-compr.h
@@ -228,7 +228,9 @@ class PtrComprCageAccessScope final {
   const Address code_cage_base_;
 #endif  // V8_EXTERNAL_CODE_SPACE
   IsolateGroup* saved_current_isolate_group_;
+#ifdef V8_ENABLE_SANDBOX
   Sandbox* saved_current_sandbox_;
+#endif
 #endif  // V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
 };
 

--- a/src/common/ptr-compr.h
+++ b/src/common/ptr-compr.h
@@ -11,6 +11,7 @@
 namespace v8::internal {
 
 class IsolateGroup;
+class Sandbox;
 
 // This is just a collection of common compression scheme related functions.
 // Each pointer compression cage then has its own compression scheme, which
@@ -227,6 +228,7 @@ class PtrComprCageAccessScope final {
   const Address code_cage_base_;
 #endif  // V8_EXTERNAL_CODE_SPACE
   IsolateGroup* saved_current_isolate_group_;
+  Sandbox* saved_current_sandbox_;
 #endif  // V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
 };
 

--- a/src/d8/d8.cc
+++ b/src/d8/d8.cc
@@ -295,7 +295,7 @@ class MultiMappedAllocator : public ArrayBufferAllocatorBase {
     // sandbox's virtual address space to essentially just reserve a number of
     // OS pages inside the sandbox, but then using mremap to replace these
     // pages directly afterwards. In practice, this works fine however.
-    VirtualAddressSpace* vas = i::GetProcessWideSandbox()->address_space();
+    VirtualAddressSpace* vas = i::Sandbox::current()->address_space();
     i::Address in_sandbox_page_reservation = vas->AllocatePages(
         VirtualAddressSpace::kNoHint, rounded_length,
         vas->allocation_granularity(), PagePermissions::kNoAccess);
@@ -353,7 +353,7 @@ class MultiMappedAllocator : public ArrayBufferAllocatorBase {
     munmap(real_alloc, kChunkSize);
     size_t rounded_length = RoundUp(length, kChunkSize);
 #ifdef V8_ENABLE_SANDBOX
-    VirtualAddressSpace* vas = i::GetProcessWideSandbox()->address_space();
+    VirtualAddressSpace* vas = i::Sandbox::current()->address_space();
     vas->FreePages(reinterpret_cast<i::Address>(data), rounded_length);
 #else
     munmap(data, rounded_length);

--- a/src/diagnostics/objects-debug.cc
+++ b/src/diagnostics/objects-debug.cc
@@ -810,7 +810,7 @@ void FeedbackCell::FeedbackCellVerify(Isolate* isolate) {
   JSDispatchHandle handle = dispatch_handle();
   if (handle == kNullJSDispatchHandle) return;
 
-  JSDispatchTable* jdt = GetProcessWideJSDispatchTable();
+  JSDispatchTable* jdt = IsolateGroup::current()->js_dispatch_table();
   Tagged<Code> code = jdt->GetCode(handle);
   CodeKind kind = code->kind();
   CHECK(kind == CodeKind::FOR_TESTING || kind == CodeKind::BUILTIN ||
@@ -1254,7 +1254,7 @@ void JSFunction::JSFunctionVerify(Isolate* isolate) {
   CHECK_EQ(map()->map()->native_context_or_null(), native_context());
 
 #ifdef V8_ENABLE_LEAPTIERING
-  JSDispatchTable* jdt = GetProcessWideJSDispatchTable();
+  JSDispatchTable* jdt = IsolateGroup::current()->js_dispatch_table();
   JSDispatchHandle handle = dispatch_handle();
   CHECK_NE(handle, kNullJSDispatchHandle);
   uint16_t parameter_count = jdt->GetParameterCount(handle);

--- a/src/diagnostics/objects-printer.cc
+++ b/src/diagnostics/objects-printer.cc
@@ -4143,7 +4143,7 @@ V8_EXPORT_PRIVATE extern void _v8_internal_Print_Code(void* object) {
 V8_DONT_STRIP_SYMBOL
 V8_EXPORT_PRIVATE extern void _v8_internal_Print_Dispatch_Handle(
     uint32_t handle) {
-  i::GetProcessWideJSDispatchTable()->PrintEntry(handle);
+  i::IsolateGroup::current()->js_dispatch_table()->PrintEntry(handle);
 }
 #endif  // V8_ENABLE_LEAPTIERING
 

--- a/src/execution/isolate.cc
+++ b/src/execution/isolate.cc
@@ -4523,7 +4523,7 @@ void Isolate::Deinit() {
       heap()->code_pointer_space());
 #endif  // V8_ENABLE_SANDBOX
 #ifdef V8_ENABLE_LEAPTIERING
-  GetProcessWideJSDispatchTable()->TearDownSpace(
+  IsolateGroup::current()->js_dispatch_table()->TearDownSpace(
       heap()->js_dispatch_table_space());
 #endif  // V8_ENABLE_LEAPTIERING
 
@@ -5592,7 +5592,7 @@ bool Isolate::Init(SnapshotData* startup_snapshot_data,
 
 #endif  // V8_ENABLE_SANDBOX
 #ifdef V8_ENABLE_LEAPTIERING
-  GetProcessWideJSDispatchTable()->InitializeSpace(
+  IsolateGroup::current()->js_dispatch_table()->InitializeSpace(
       heap()->js_dispatch_table_space());
 #endif  // V8_ENABLE_LEAPTIERING
 
@@ -7511,7 +7511,7 @@ void Isolate::InitializeBuiltinJSDispatchTable() {
   // is not initialized multiple times. This must be blocking as no isolate
   // should be allowed to proceed until the table is initialized.
   base::MutexGuard guard(read_only_dispatch_entries_mutex_.Pointer());
-  auto jdt = GetProcessWideJSDispatchTable();
+  JSDispatchTable* jdt = IsolateGroup::current()->js_dispatch_table();
   if (jdt->PreAllocatedEntryNeedsInitialization(
           read_only_heap_->js_dispatch_table_space(),
           builtin_dispatch_handle(JSBuiltinDispatchHandleRoot::Idx::kFirst))) {

--- a/src/execution/isolate.cc
+++ b/src/execution/isolate.cc
@@ -4540,6 +4540,9 @@ void Isolate::SetIsolateThreadLocals(Isolate* isolate,
   ExternalCodeCompressionScheme::InitBase(isolate ? isolate->code_cage_base()
                                                   : kNullAddress);
 #endif
+#ifdef V8_ENABLE_SANDBOX
+  Sandbox::set_current(isolate ? isolate->isolate_group()->sandbox() : nullptr);
+#endif
 #endif  // V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
 
   if (isolate && isolate->main_thread_local_isolate()) {

--- a/src/execution/isolate.cc
+++ b/src/execution/isolate.cc
@@ -4535,7 +4535,7 @@ void Isolate::SetIsolateThreadLocals(Isolate* isolate,
 #ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
   V8HeapCompressionScheme::InitBase(isolate ? isolate->cage_base()
                                             : kNullAddress);
-  IsolateGroup::set_current(isolate ? isolate->isolate_group() : nullptr);
+  if (isolate) IsolateGroup::set_current(isolate->isolate_group());
 #ifdef V8_EXTERNAL_CODE_SPACE
   ExternalCodeCompressionScheme::InitBase(isolate ? isolate->code_cage_base()
                                                   : kNullAddress);

--- a/src/execution/isolate.cc
+++ b/src/execution/isolate.cc
@@ -3985,22 +3985,16 @@ namespace {
 bool HasFlagThatRequiresSharedHeap() {
   return v8_flags.shared_string_table || v8_flags.harmony_struct;
 }
-
-IsolateGroup* AcquireGroupForNewIsolate() {
-  IsolateGroup* group = IsolateGroup::AcquireGlobal();
-  if (group) return group;
-  return IsolateGroup::New();
-}
 }  // namespace
 
 // static
-Isolate* Isolate::New() { return Allocate(); }
+Isolate* Isolate::New() { return New(IsolateGroup::AcquireDefault()); }
+Isolate* Isolate::New(IsolateGroup* group) { return Allocate(group); }
 
 // static
-Isolate* Isolate::Allocate() {
+Isolate* Isolate::Allocate(IsolateGroup* group) {
   // v8::V8::Initialize() must be called before creating any isolates.
   DCHECK_NOT_NULL(V8::GetCurrentPlatform());
-  IsolateGroup* group = AcquireGroupForNewIsolate();
   // Allocate Isolate itself on C++ heap, ensuring page alignment.
   void* isolate_ptr = base::AlignedAlloc(sizeof(Isolate), kMinimumOSPageSize);
   // IsolateAllocator manages the virtual memory resources for the Isolate.

--- a/src/execution/isolate.cc
+++ b/src/execution/isolate.cc
@@ -4649,14 +4649,12 @@ Isolate::~Isolate() {
 
 void Isolate::InitializeThreadLocal() {
   thread_local_top()->Initialize(this);
-#ifdef DEBUG
   // This method might be called on a thread that's not bound to any Isolate
   // and thus pointer compression schemes might have cage base value unset.
   // Read-only roots accessors contain type DCHECKs which require access to
   // V8 heap in order to check the object type. So, allow heap access here
   // to let the checks work.
   i::PtrComprCageAccessScope ptr_compr_cage_access_scope(this);
-#endif  // DEBUG
   clear_exception();
   clear_pending_message();
 }

--- a/src/execution/isolate.h
+++ b/src/execution/isolate.h
@@ -644,6 +644,7 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
   // Creates Isolate object. Must be used instead of constructing Isolate with
   // new operator.
   static Isolate* New();
+  static Isolate* New(IsolateGroup* isolate_group);
 
   // Deletes Isolate object. Must be used instead of delete operator.
   // Destroys the non-default isolates.
@@ -2310,7 +2311,7 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
   explicit Isolate(IsolateGroup* isolate_group);
   ~Isolate();
 
-  static Isolate* Allocate();
+  static Isolate* Allocate(IsolateGroup* isolate_group);
 
   bool Init(SnapshotData* startup_snapshot_data,
             SnapshotData* read_only_snapshot_data,

--- a/src/execution/v8threads.cc
+++ b/src/execution/v8threads.cc
@@ -278,14 +278,13 @@ void ThreadManager::EagerlyArchiveThread() {
 }
 
 void ThreadManager::FreeThreadResources() {
-#ifdef DEBUG
   // This method might be called on a thread that's not bound to any Isolate
   // and thus pointer compression schemes might have cage base value unset.
   // Read-only roots accessors contain type DCHECKs which require access to
   // V8 heap in order to check the object type. So, allow heap access here
   // to let the checks work.
   PtrComprCageAccessScope ptr_compr_cage_access_scope(isolate_);
-#endif  // DEBUG
+
   DCHECK(!isolate_->has_exception());
   DCHECK_NULL(isolate_->try_catch_handler());
   isolate_->handle_scope_implementer()->FreeThreadResources();

--- a/src/heap/array-buffer-sweeper.cc
+++ b/src/heap/array-buffer-sweeper.cc
@@ -196,6 +196,7 @@ class ArrayBufferSweeper::SweepingState::SweepingJob final : public JobTask {
 
 void ArrayBufferSweeper::SweepingState::SweepingJob::Run(
     JobDelegate* delegate) {
+  PtrComprCageAccessScope ptr_compr_cage_access_scope(heap_->isolate());
   const ThreadKind thread_kind =
       delegate->IsJoiningThread() ? ThreadKind::kMain : ThreadKind::kBackground;
   if (treat_all_young_as_promoted_ == TreatAllYoungAsPromoted::kNo) {

--- a/src/heap/cppgc/concurrent-marker.h
+++ b/src/heap/cppgc/concurrent-marker.h
@@ -10,13 +10,15 @@
 #include "src/heap/cppgc/marking-state.h"
 #include "src/heap/cppgc/marking-visitor.h"
 #include "src/heap/cppgc/marking-worklists.h"
+#include "src/init/isolate-group.h"
 
 namespace cppgc {
 namespace internal {
 
 class V8_EXPORT_PRIVATE ConcurrentMarkerBase {
  public:
-  ConcurrentMarkerBase(HeapBase&, MarkingWorklists&,
+  ConcurrentMarkerBase(v8::internal::IsolateGroup* isolate_group, HeapBase&,
+                       MarkingWorklists&,
                        heap::base::IncrementalMarkingSchedule&,
                        cppgc::Platform*);
   virtual ~ConcurrentMarkerBase();
@@ -48,6 +50,7 @@ class V8_EXPORT_PRIVATE ConcurrentMarkerBase {
   void IncreaseMarkingPriorityIfNeeded();
 
  private:
+  v8::internal::IsolateGroup* isolate_group_ = nullptr;
   HeapBase& heap_;
   MarkingWorklists& marking_worklists_;
   heap::base::IncrementalMarkingSchedule& incremental_marking_schedule_;
@@ -64,10 +67,11 @@ class V8_EXPORT_PRIVATE ConcurrentMarkerBase {
 class V8_EXPORT_PRIVATE ConcurrentMarker : public ConcurrentMarkerBase {
  public:
   ConcurrentMarker(
-      HeapBase& heap, MarkingWorklists& marking_worklists,
+      v8::internal::IsolateGroup* isolate_group, HeapBase& heap,
+      MarkingWorklists& marking_worklists,
       heap::base::IncrementalMarkingSchedule& incremental_marking_schedule,
       cppgc::Platform* platform)
-      : ConcurrentMarkerBase(heap, marking_worklists,
+      : ConcurrentMarkerBase(isolate_group, heap, marking_worklists,
                              incremental_marking_schedule, platform) {}
 
   std::unique_ptr<Visitor> CreateConcurrentMarkingVisitor(

--- a/src/heap/cppgc/heap.cc
+++ b/src/heap/cppgc/heap.cc
@@ -17,6 +17,7 @@
 #include "src/heap/cppgc/stats-collector.h"
 #include "src/heap/cppgc/sweeper.h"
 #include "src/heap/cppgc/unmarker.h"
+#include "src/init/isolate-group.h"
 
 namespace cppgc {
 
@@ -163,7 +164,8 @@ void Heap::StartGarbageCollection(GCConfig config) {
 
   const MarkingConfig marking_config{config.collection_type, config.stack_state,
                                      config.marking_type, config.is_forced_gc};
-  marker_ = std::make_unique<Marker>(AsBase(), platform_.get(), marking_config);
+  marker_ = std::make_unique<Marker>(v8::internal::IsolateGroup::current(),
+                                     AsBase(), platform_.get(), marking_config);
   marker_->StartMarking();
 }
 

--- a/src/heap/cppgc/marker.cc
+++ b/src/heap/cppgc/marker.cc
@@ -25,6 +25,7 @@
 #include "src/heap/cppgc/process-heap.h"
 #include "src/heap/cppgc/stats-collector.h"
 #include "src/heap/cppgc/write-barrier.h"
+#include "src/init/isolate-group.h"
 
 #if defined(CPPGC_CAGED_HEAP)
 #include "include/cppgc/internal/caged-heap-local-data.h"
@@ -775,13 +776,14 @@ MarkerBase::PauseConcurrentMarkingScope::~PauseConcurrentMarkingScope() {
   }
 }
 
-Marker::Marker(HeapBase& heap, cppgc::Platform* platform, MarkingConfig config)
+Marker::Marker(v8::internal::IsolateGroup* isolate_group, HeapBase& heap,
+               cppgc::Platform* platform, MarkingConfig config)
     : MarkerBase(heap, platform, config),
       marking_visitor_(heap, mutator_marking_state_),
       conservative_marking_visitor_(heap, mutator_marking_state_,
                                     marking_visitor_) {
   concurrent_marker_ = std::make_unique<ConcurrentMarker>(
-      heap_, marking_worklists_, *schedule_, platform_);
+      isolate_group, heap_, marking_worklists_, *schedule_, platform_);
 }
 
 }  // namespace internal

--- a/src/heap/cppgc/marker.h
+++ b/src/heap/cppgc/marker.h
@@ -199,7 +199,8 @@ class V8_EXPORT_PRIVATE MarkerBase {
 
 class V8_EXPORT_PRIVATE Marker final : public MarkerBase {
  public:
-  Marker(HeapBase&, cppgc::Platform*, MarkingConfig = MarkingConfig::Default());
+  Marker(v8::internal::IsolateGroup*, HeapBase&, cppgc::Platform*,
+         MarkingConfig = MarkingConfig::Default());
 
  protected:
   cppgc::Visitor& visitor() final { return marking_visitor_; }

--- a/src/heap/factory.cc
+++ b/src/heap/factory.cc
@@ -4748,7 +4748,7 @@ Handle<JSFunction> Factory::JSFunctionBuilder::BuildRaw(
     // if we would UpdateCode we would risk tiering down already existing
     // closures with optimized code installed.
     JSDispatchHandle handle = feedback_cell->dispatch_handle();
-    JSDispatchTable* jdt = GetProcessWideJSDispatchTable();
+    JSDispatchTable* jdt = IsolateGroup::current()->js_dispatch_table();
     // TODO(olivf): We should go through the cases where this is still needed
     // and maybe find some alternative to initialize it correctly from the
     // beginning.

--- a/src/heap/heap-write-barrier.cc
+++ b/src/heap/heap-write-barrier.cc
@@ -177,7 +177,7 @@ void WriteBarrier::MarkingSlow(Tagged<HeapObject> host,
   if (marking_barrier->is_minor()) return;
 
   // Mark both the table entry and its content.
-  JSDispatchTable* jdt = GetProcessWideJSDispatchTable();
+  JSDispatchTable* jdt = IsolateGroup::current()->js_dispatch_table();
   static_assert(JSDispatchTable::kWriteBarrierSetsEntryMarkBit);
   jdt->Mark(handle);
   marking_barrier->MarkValue(host, jdt->GetCode(handle));
@@ -535,9 +535,9 @@ bool WriteBarrier::VerifyDispatchHandleMarkingState(Tagged<HeapObject> host,
                                                     JSDispatchHandle handle,
                                                     WriteBarrierMode mode) {
 #ifdef V8_ENABLE_LEAPTIERING
+  JSDispatchTable* jdt = IsolateGroup::current()->js_dispatch_table();
   if (mode == SKIP_WRITE_BARRIER &&
-      WriteBarrier::IsRequired(
-          host, GetProcessWideJSDispatchTable()->GetCode(handle))) {
+      WriteBarrier::IsRequired(host, jdt->GetCode(handle))) {
     return false;
   }
 
@@ -551,10 +551,10 @@ bool WriteBarrier::VerifyDispatchHandleMarkingState(Tagged<HeapObject> host,
       !CurrentMarkingBarrier(host)->IsMarked(host)) {
     return true;
   }
-  if (GetProcessWideJSDispatchTable()->IsMarked(handle)) {
+  if (jdt->IsMarked(handle)) {
     return true;
   }
-  Tagged<Code> value = GetProcessWideJSDispatchTable()->GetCode(handle);
+  Tagged<Code> value = jdt->GetCode(handle);
   if (ReadOnlyHeap::Contains(value)) {
     return true;
   }

--- a/src/heap/mark-compact.cc
+++ b/src/heap/mark-compact.cc
@@ -3015,7 +3015,7 @@ void MarkCompactCollector::ClearNonLiveReferences() {
 #ifdef V8_ENABLE_LEAPTIERING
   {
     TRACE_GC(heap_->tracer(), GCTracer::Scope::MC_SWEEP_JS_DISPATCH_TABLE);
-    JSDispatchTable* jdt = GetProcessWideJSDispatchTable();
+    JSDispatchTable* jdt = IsolateGroup::current()->js_dispatch_table();
     Tagged<Code> compile_lazy = *BUILTIN_CODE(heap_->isolate(), CompileLazy);
     jdt->Sweep(heap_->js_dispatch_table_space(), isolate->counters(),
                [&](JSDispatchEntry& entry) {
@@ -5698,7 +5698,7 @@ void MarkCompactCollector::UpdatePointersInPointerTables() {
 #endif  // V8_ENABLE_SANDBOX
 
 #ifdef V8_ENABLE_LEAPTIERING
-  JSDispatchTable* const jdt = GetProcessWideJSDispatchTable();
+  JSDispatchTable* const jdt = IsolateGroup::current()->js_dispatch_table();
   jdt->IterateActiveEntriesIn(
       heap_->js_dispatch_table_space(), [&](JSDispatchHandle handle) {
         Address code_address = jdt->GetCodeAddress(handle);

--- a/src/heap/marking-visitor-inl.h
+++ b/src/heap/marking-visitor-inl.h
@@ -298,15 +298,15 @@ template <typename ConcreteVisitor>
 void MarkingVisitorBase<ConcreteVisitor>::VisitJSDispatchTableEntry(
     Tagged<HeapObject> host, JSDispatchHandle handle) {
 #ifdef V8_ENABLE_LEAPTIERING
-  JSDispatchTable* table = GetProcessWideJSDispatchTable();
+  JSDispatchTable* jdt = IsolateGroup::current()->js_dispatch_table();
 #ifdef DEBUG
   JSDispatchTable::Space* space = heap_->js_dispatch_table_space();
   JSDispatchTable::Space* ro_space =
       heap_->isolate()->read_only_heap()->js_dispatch_table_space();
-  table->VerifyEntry(handle, space, ro_space);
+  jdt->VerifyEntry(handle, space, ro_space);
 #endif  // DEBUG
 
-  table->Mark(handle);
+  jdt->Mark(handle);
 
   // The code objects referenced from a dispatch table entry are treated as weak
   // references for the purpose of bytecode/baseline flushing, so they are not
@@ -337,7 +337,8 @@ size_t MarkingVisitorBase<ConcreteVisitor>::VisitJSFunction(
   JSDispatchHandle handle = js_function->Relaxed_ReadField<JSDispatchHandle>(
       JSFunction::kDispatchHandleOffset);
   if (handle != kNullJSDispatchHandle) {
-    Tagged<HeapObject> obj = GetProcessWideJSDispatchTable()->GetCode(handle);
+    Tagged<HeapObject> obj =
+        IsolateGroup::current()->js_dispatch_table()->GetCode(handle);
     // TODO(saelo): maybe factor out common code with VisitIndirectPointer
     // into a helper routine?
     SynchronizePageAccess(obj);

--- a/src/heap/memory-chunk-constants.h
+++ b/src/heap/memory-chunk-constants.h
@@ -1,0 +1,43 @@
+// Copyright 2024 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef V8_HEAP_MEMORY_CHUNK_CONSTANTS_H_
+#define V8_HEAP_MEMORY_CHUNK_CONSTANTS_H_
+
+#include "include/v8-internal.h"
+#include "src/base/bits.h"
+#include "src/common/globals.h"
+
+namespace v8 {
+namespace internal {
+
+class V8_EXPORT_PRIVATE MemoryChunkConstants final : public AllStatic {
+ public:
+#ifdef V8_ENABLE_SANDBOX
+  static constexpr size_t kPagesInMainCage =
+      kPtrComprCageReservationSize / kRegularPageSize;
+  static constexpr size_t kPagesInCodeCage =
+      kMaximalCodeRangeSize / kRegularPageSize;
+  static constexpr size_t kPagesInTrustedCage =
+      kMaximalTrustedRangeSize / kRegularPageSize;
+
+  static constexpr size_t kMainCageMetadataOffset = 0;
+  static constexpr size_t kTrustedSpaceMetadataOffset =
+      kMainCageMetadataOffset + kPagesInMainCage;
+  static constexpr size_t kCodeRangeMetadataOffset =
+      kTrustedSpaceMetadataOffset + kPagesInTrustedCage;
+
+  static constexpr size_t kMetadataPointerTableSizeLog2 = base::bits::BitWidth(
+      kPagesInMainCage + kPagesInCodeCage + kPagesInTrustedCage);
+  static constexpr size_t kMetadataPointerTableSize =
+      1 << kMetadataPointerTableSizeLog2;
+  static constexpr size_t kMetadataPointerTableSizeMask =
+      kMetadataPointerTableSize - 1;
+#endif  // V8_ENABLE_SANDBOX
+};
+
+}  // namespace internal
+}  // namespace v8
+
+#endif  // V8_HEAP_MEMORY_CHUNK_CONSTANTS_H_

--- a/src/heap/read-only-heap.cc
+++ b/src/heap/read-only-heap.cc
@@ -34,9 +34,9 @@ ReadOnlyHeap::~ReadOnlyHeap() {
       &code_pointer_space_);
 #endif
 #ifdef V8_ENABLE_LEAPTIERING
-  GetProcessWideJSDispatchTable()->DetachSpaceFromReadOnlySegment(
-      &js_dispatch_table_space_);
-  GetProcessWideJSDispatchTable()->TearDownSpace(&js_dispatch_table_space_);
+  JSDispatchTable* jdt = IsolateGroup::current()->js_dispatch_table();
+  jdt->DetachSpaceFromReadOnlySegment(&js_dispatch_table_space_);
+  jdt->TearDownSpace(&js_dispatch_table_space_);
 #endif
 }
 
@@ -215,16 +215,16 @@ ReadOnlyHeap::ReadOnlyHeap(ReadOnlySpace* ro_space)
       &code_pointer_space_);
 #endif  // V8_ENABLE_SANDBOX
 #ifdef V8_ENABLE_LEAPTIERING
-  GetProcessWideJSDispatchTable()->InitializeSpace(&js_dispatch_table_space_);
+  JSDispatchTable* jdt = IsolateGroup::current()->js_dispatch_table();
+  jdt->InitializeSpace(&js_dispatch_table_space_);
   // To avoid marking trying to write to these read-only cells they are
   // allocated black. Target code objects in the read-only dispatch table are
   // read-only code objects.
   js_dispatch_table_space_.set_allocate_black(true);
-  GetProcessWideJSDispatchTable()->AttachSpaceToReadOnlySegment(
-      &js_dispatch_table_space_);
-  GetProcessWideJSDispatchTable()->PreAllocateEntries(
-      &js_dispatch_table_space_, JSBuiltinDispatchHandleRoot::kCount,
-      Isolate::kBuiltinDispatchHandlesAreStatic);
+  jdt->AttachSpaceToReadOnlySegment(&js_dispatch_table_space_);
+  jdt->PreAllocateEntries(&js_dispatch_table_space_,
+                          JSBuiltinDispatchHandleRoot::kCount,
+                          Isolate::kBuiltinDispatchHandlesAreStatic);
 #endif  // V8_ENABLE_LEAPTIERING
 }
 

--- a/src/heap/read-only-promotion.cc
+++ b/src/heap/read-only-promotion.cc
@@ -345,7 +345,7 @@ class ReadOnlyPromotionImpl final : public AllStatic {
 #ifdef V8_ENABLE_LEAPTIERING
     // Iterate all entries in the JSDispatchTable as they could contain
     // pointers to promoted Code objects.
-    JSDispatchTable* const jdt = GetProcessWideJSDispatchTable();
+    JSDispatchTable* const jdt = IsolateGroup::current()->js_dispatch_table();
     jdt->IterateActiveEntriesIn(heap->js_dispatch_table_space(),
                                 [&](JSDispatchHandle handle) {
                                   Tagged<Code> old_code = jdt->GetCode(handle);

--- a/src/init/isolate-group.cc
+++ b/src/init/isolate-group.cc
@@ -61,13 +61,11 @@ struct PtrComprCageReservationParams
 };
 #endif  // V8_COMPRESS_POINTERS
 
-#ifndef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
 // static
-IsolateGroup* IsolateGroup::GetProcessWideIsolateGroup() {
-  static ::v8::base::LeakyObject<IsolateGroup> global_isolate_group_;
-  return global_isolate_group_.get();
+IsolateGroup* IsolateGroup::GetDefault() {
+  static base::LeakyObject<IsolateGroup> default_isolate_group_;
+  return default_isolate_group_.get();
 }
-#endif  // V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
 
 IsolateGroup::IsolateGroup() {}
 IsolateGroup::~IsolateGroup() {
@@ -128,9 +126,9 @@ void IsolateGroup::Initialize(bool process_wide) {
 
 // static
 void IsolateGroup::InitializeOncePerProcess() {
-#ifndef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
-  IsolateGroup* group = GetProcessWideIsolateGroup();
+  IsolateGroup* group = GetDefault();
 
+  DCHECK_NULL(group->page_allocator_);
 #ifdef V8_ENABLE_SANDBOX
   group->Initialize(true, GetProcessWideSandbox());
 #else
@@ -147,7 +145,9 @@ void IsolateGroup::InitializeOncePerProcess() {
   // the code cage base will be set accordingly.
   ExternalCodeCompressionScheme::InitBase(V8HeapCompressionScheme::base());
 #endif  // V8_EXTERNAL_CODE_SPACE
-#endif  // !V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  IsolateGroup::set_current(group);
+#endif
 }
 
 namespace {
@@ -195,17 +195,19 @@ ReadOnlyArtifacts* IsolateGroup::InitializeReadOnlyArtifacts() {
 
 // static
 IsolateGroup* IsolateGroup::New() {
+  if (!CanCreateNewGroups()) {
+    FATAL(
+        "Creation of new isolate groups requires enabling "
+        "multiple pointer compression cages at build-time");
+  }
+
   IsolateGroup* group = new IsolateGroup;
-
-#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
-  static_assert(!V8_ENABLE_SANDBOX_BOOL);
-  group->Initialize(false);
+#ifdef V8_ENABLE_SANDBOX
+  // TODO(42204573): Support creation of multiple sandboxes.
+  UNREACHABLE();
 #else
-  FATAL(
-      "Creation of new isolate groups requires enabling "
-      "multiple pointer compression cages at build-time");
+  group->Initialize(false);
 #endif
-
   CHECK_NOT_NULL(group->page_allocator_);
   ExternalReferenceTable::InitializeOncePerIsolateGroup(
       group->external_ref_table());
@@ -213,18 +215,8 @@ IsolateGroup* IsolateGroup::New() {
 }
 
 // static
-IsolateGroup* IsolateGroup::AcquireGlobal() {
-#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
-  return nullptr;
-#else
-  return GetProcessWideIsolateGroup()->Acquire();
-#endif  // V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
-}
-
-// static
-void IsolateGroup::ReleaseGlobal() {
-#ifndef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
-  IsolateGroup *group = GetProcessWideIsolateGroup();
+void IsolateGroup::ReleaseDefault() {
+  IsolateGroup* group = GetDefault();
   CHECK_EQ(group->reference_count_.load(), 1);
   CHECK(!group->has_shared_space_isolate());
   group->page_allocator_ = nullptr;
@@ -236,7 +228,7 @@ void IsolateGroup::ReleaseGlobal() {
   DCHECK(group->reservation_.IsReserved());
   group->reservation_.Free();
 #endif  // V8_COMPRESS_POINTERS
-#endif  // V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  group->code_range_.reset();
 }
 
 }  // namespace internal

--- a/src/init/isolate-group.cc
+++ b/src/init/isolate-group.cc
@@ -12,6 +12,7 @@
 #include "src/heap/code-range.h"
 #include "src/heap/read-only-spaces.h"
 #include "src/heap/trusted-range.h"
+#include "src/sandbox/external-entity-table-inl.h"
 #include "src/sandbox/sandbox.h"
 #include "src/utils/memcopy.h"
 #include "src/utils/utils.h"

--- a/src/init/isolate-group.cc
+++ b/src/init/isolate-group.cc
@@ -101,6 +101,7 @@ void IsolateGroup::Initialize(bool process_wide, Sandbox* sandbox) {
   pointer_compression_cage_ = &reservation_;
   trusted_pointer_compression_cage_ =
       TrustedRange::EnsureProcessWideTrustedRange(kMaximalTrustedRangeSize);
+  sandbox_ = sandbox;
 }
 #elif defined(V8_COMPRESS_POINTERS)
 void IsolateGroup::Initialize(bool process_wide) {
@@ -130,7 +131,7 @@ void IsolateGroup::InitializeOncePerProcess() {
 
   DCHECK_NULL(group->page_allocator_);
 #ifdef V8_ENABLE_SANDBOX
-  group->Initialize(true, GetProcessWideSandbox());
+  group->Initialize(true, GetDefaultSandbox());
 #else
   group->Initialize(true);
 #endif
@@ -147,6 +148,7 @@ void IsolateGroup::InitializeOncePerProcess() {
 #endif  // V8_EXTERNAL_CODE_SPACE
 #ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
   IsolateGroup::set_current(group);
+  Sandbox::set_current(GetDefaultSandbox());
 #endif
 }
 

--- a/src/init/isolate-group.h
+++ b/src/init/isolate-group.h
@@ -16,6 +16,7 @@
 #include "src/flags/flags.h"
 #include "src/heap/memory-chunk-constants.h"
 #include "src/sandbox/code-pointer-table.h"
+#include "src/sandbox/js-dispatch-table.h"
 #include "src/utils/allocation.h"
 
 namespace v8 {
@@ -163,6 +164,7 @@ class V8_EXPORT_PRIVATE IsolateGroup final {
 
 #ifdef V8_ENABLE_SANDBOX
   CodePointerTable* code_pointer_table() { return &code_pointer_table_; }
+  JSDispatchTable* js_dispatch_table() { return &js_dispatch_table_; }
 
   MemoryChunkMetadata** metadata_pointer_table() {
     return metadata_pointer_table_;
@@ -229,6 +231,7 @@ class V8_EXPORT_PRIVATE IsolateGroup final {
 
 #ifdef V8_ENABLE_SANDBOX
   CodePointerTable code_pointer_table_;
+  JSDispatchTable js_dispatch_table_;
 
   MemoryChunkMetadata*
       metadata_pointer_table_[MemoryChunkConstants::kMetadataPointerTableSize] =

--- a/src/init/isolate-group.h
+++ b/src/init/isolate-group.h
@@ -11,7 +11,6 @@
 #include "src/base/once.h"
 #include "src/base/page-allocator.h"
 #include "src/base/platform/mutex.h"
-#include "src/codegen/external-reference-table.h"
 #include "src/common/globals.h"
 #include "src/flags/flags.h"
 #include "src/heap/memory-chunk-constants.h"
@@ -127,7 +126,7 @@ class V8_EXPORT_PRIVATE IsolateGroup final {
   static IsolateGroup* current() { return GetDefault(); }
 #endif  // !V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
 
-  MemorySpan<Address> external_ref_table() { return external_ref_table_; }
+  MemorySpan<Address> external_ref_table();
 
   bool has_shared_space_isolate() const {
     return shared_space_isolate_ != nullptr;
@@ -214,8 +213,7 @@ class V8_EXPORT_PRIVATE IsolateGroup final {
 
   base::OnceType init_code_range_ = V8_ONCE_INIT;
   std::unique_ptr<CodeRange> code_range_;
-  Address external_ref_table_[ExternalReferenceTable::kSizeIsolateIndependent] =
-      {0};
+  std::vector<Address> external_ref_table_;
 
   bool process_wide_;
 

--- a/src/init/isolate-group.h
+++ b/src/init/isolate-group.h
@@ -90,10 +90,7 @@ class V8_EXPORT_PRIVATE IsolateGroup final {
 
   // Release a reference on an isolate group, possibly freeing any shared memory
   // resources.
-  void Release() {
-    DCHECK_LT(0, reference_count_.load());
-    if (--reference_count_ == 0) delete this;
-  }
+  void Release();
 
   int IncrementIsolateCount() { return ++isolate_count_; }
   int DecrementIsolateCount() { return --isolate_count_; }
@@ -171,7 +168,7 @@ class V8_EXPORT_PRIVATE IsolateGroup final {
   MemoryChunkMetadata** metadata_pointer_table() {
     return metadata_pointer_table_;
   }
-  
+
   Sandbox* sandbox() { return sandbox_; }
 #endif  // V8_ENABLE_SANDBOX
 
@@ -235,7 +232,7 @@ class V8_EXPORT_PRIVATE IsolateGroup final {
   MemoryChunkMetadata*
       metadata_pointer_table_[MemoryChunkConstants::kMetadataPointerTableSize] =
           {nullptr};
-          
+
   Sandbox* sandbox_ = nullptr;
 #endif  // V8_ENABLE_SANDBOX
 };

--- a/src/init/isolate-group.h
+++ b/src/init/isolate-group.h
@@ -14,6 +14,7 @@
 #include "src/codegen/external-reference-table.h"
 #include "src/common/globals.h"
 #include "src/flags/flags.h"
+#include "src/heap/memory-chunk-constants.h"
 #include "src/sandbox/code-pointer-table.h"
 #include "src/utils/allocation.h"
 
@@ -33,6 +34,7 @@ class CodeRange;
 class Isolate;
 class ReadOnlyHeap;
 class ReadOnlyArtifacts;
+class MemoryChunkMetadata;
 
 // An IsolateGroup allows an API user to control which isolates get allocated
 // together in a shared pointer cage.
@@ -161,6 +163,10 @@ class V8_EXPORT_PRIVATE IsolateGroup final {
 
 #ifdef V8_ENABLE_SANDBOX
   CodePointerTable* code_pointer_table() { return &code_pointer_table_; }
+
+  MemoryChunkMetadata** metadata_pointer_table() {
+    return metadata_pointer_table_;
+  }
 #endif  // V8_ENABLE_SANDBOX
 
  private:
@@ -223,6 +229,10 @@ class V8_EXPORT_PRIVATE IsolateGroup final {
 
 #ifdef V8_ENABLE_SANDBOX
   CodePointerTable code_pointer_table_;
+
+  MemoryChunkMetadata*
+      metadata_pointer_table_[MemoryChunkConstants::kMetadataPointerTableSize] =
+          {nullptr};
 #endif  // V8_ENABLE_SANDBOX
 };
 

--- a/src/init/isolate-group.h
+++ b/src/init/isolate-group.h
@@ -171,6 +171,8 @@ class V8_EXPORT_PRIVATE IsolateGroup final {
   MemoryChunkMetadata** metadata_pointer_table() {
     return metadata_pointer_table_;
   }
+  
+  Sandbox* sandbox() { return sandbox_; }
 #endif  // V8_ENABLE_SANDBOX
 
  private:
@@ -233,6 +235,8 @@ class V8_EXPORT_PRIVATE IsolateGroup final {
   MemoryChunkMetadata*
       metadata_pointer_table_[MemoryChunkConstants::kMetadataPointerTableSize] =
           {nullptr};
+          
+  Sandbox* sandbox_ = nullptr;
 #endif  // V8_ENABLE_SANDBOX
 };
 

--- a/src/init/isolate-group.h
+++ b/src/init/isolate-group.h
@@ -55,27 +55,29 @@ class MemoryChunkMetadata;
 // Isolate groups are useful only if pointer compression is enabled.  Otherwise,
 // the isolate could just allocate pages from the global system allocator;
 // there's no need to stay within any particular address range.  If pointer
-// compression is disabled, isolate groups are a no-op.
+// compression is disabled, there is just one global isolate group.
 //
 // Note that JavaScript objects can only be passed between isolates of the same
 // group.  Ensuring this invariant is the responsibility of the API user.
 class V8_EXPORT_PRIVATE IsolateGroup final {
  public:
+  // InitializeOncePerProcess should be called early on to initialize the
+  // process-wide group.
+  static IsolateGroup* AcquireDefault() { return GetDefault()->Acquire(); }
+
+  // Return true if we can create additional isolate groups: only the case if
+  // multiple pointer cages were configured in at build-time.
+  static constexpr bool CanCreateNewGroups() {
+    return COMPRESS_POINTERS_IN_MULTIPLE_CAGES_BOOL;
+  }
+
   // Create a new isolate group, allocating a fresh pointer cage if pointer
-  // compression is enabled.
+  // compression is enabled.  If new groups cannot be created in this build
+  // configuration, abort.
   //
   // The pointer cage for isolates in this group will be released when the
   // group's refcount drops to zero.  The group's initial refcount is 1.
-  //
-  // Note that if pointer compression is disabled, isolates are not grouped and
-  // no memory is associated with the isolate group.
   static IsolateGroup* New();
-
-  // Some configurations (e.g. V8_ENABLE_SANDBOX) put all isolates into a single
-  // group.  InitializeOncePerProcess should be called early on to initialize
-  // the process-wide group.  If this configuration has no process-wide isolate
-  // group, the result is nullptr.
-  static IsolateGroup* AcquireGlobal();
 
   static void InitializeOncePerProcess();
 
@@ -125,7 +127,7 @@ class V8_EXPORT_PRIVATE IsolateGroup final {
   static void set_current(IsolateGroup* group) { current_ = group; }
 #endif  // !USING_V8_SHARED_PRIVATE
 #else   // !V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
-  static IsolateGroup* current() { return GetProcessWideIsolateGroup(); }
+  static IsolateGroup* current() { return GetDefault(); }
 #endif  // !V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
 
   MemorySpan<Address> external_ref_table() { return external_ref_table_; }
@@ -173,21 +175,16 @@ class V8_EXPORT_PRIVATE IsolateGroup final {
 
  private:
   friend class base::LeakyObject<IsolateGroup>;
-#ifndef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
-  // Unless multiple pointer compression cages are enabled, all isolates in a
-  // process are in the same isolate group and share process-wide resources from
-  // that group.
-  static IsolateGroup* GetProcessWideIsolateGroup();
-#endif  // V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  friend class PoolTest;
 
   IsolateGroup();
   ~IsolateGroup();
   IsolateGroup(const IsolateGroup&) = delete;
   IsolateGroup& operator=(const IsolateGroup&) = delete;
 
-  friend class PoolTest;
+  static IsolateGroup* GetDefault();
   // Only used for testing.
-  static void ReleaseGlobal();
+  static void ReleaseDefault();
 
 #ifdef V8_ENABLE_SANDBOX
   void Initialize(bool process_wide, Sandbox* sandbox);

--- a/src/init/v8.cc
+++ b/src/init/v8.cc
@@ -197,8 +197,10 @@ void V8::Initialize() {
 
 #ifdef V8_ENABLE_SANDBOX
   // If enabled, the sandbox must be initialized first.
-  GetDefaultSandbox()->Initialize(GetPlatformVirtualAddressSpace());
-  CHECK_EQ(kSandboxSize, GetProcessWideSandbox()->size());
+  Sandbox* sandbox = GetDefaultSandbox();
+  sandbox->Initialize(GetPlatformVirtualAddressSpace());
+  CHECK_EQ(kSandboxSize, sandbox->size());
+  Sandbox::set_current(sandbox);
 
   // Enable sandbox testing mode if requested.
   //

--- a/src/init/v8.cc
+++ b/src/init/v8.cc
@@ -197,7 +197,7 @@ void V8::Initialize() {
 
 #ifdef V8_ENABLE_SANDBOX
   // If enabled, the sandbox must be initialized first.
-  GetProcessWideSandbox()->Initialize(GetPlatformVirtualAddressSpace());
+  GetDefaultSandbox()->Initialize(GetPlatformVirtualAddressSpace());
   CHECK_EQ(kSandboxSize, GetProcessWideSandbox()->size());
 
   // Enable sandbox testing mode if requested.
@@ -284,7 +284,7 @@ void V8::DisposePlatform() {
 #ifdef V8_ENABLE_SANDBOX
   // TODO(chromium:1218005) alternatively, this could move to its own
   // public TearDownSandbox function.
-  GetProcessWideSandbox()->TearDown();
+  GetDefaultSandbox()->TearDown();
 #endif  // V8_ENABLE_SANDBOX
 
   platform_ = nullptr;

--- a/src/init/v8.cc
+++ b/src/init/v8.cc
@@ -200,9 +200,6 @@ void V8::Initialize() {
   GetProcessWideSandbox()->Initialize(GetPlatformVirtualAddressSpace());
   CHECK_EQ(kSandboxSize, GetProcessWideSandbox()->size());
 
-  IsolateGroup::current()->code_pointer_table()->Initialize();
-  IsolateGroup::current()->js_dispatch_table()->Initialize();
-
   // Enable sandbox testing mode if requested.
   //
   // This will install the sandbox crash filter to ignore all crashes that do

--- a/src/init/v8.cc
+++ b/src/init/v8.cc
@@ -201,7 +201,7 @@ void V8::Initialize() {
   CHECK_EQ(kSandboxSize, GetProcessWideSandbox()->size());
 
   IsolateGroup::current()->code_pointer_table()->Initialize();
-  JSDispatchTable::Initialize();
+  IsolateGroup::current()->js_dispatch_table()->Initialize();
 
   // Enable sandbox testing mode if requested.
   //
@@ -241,6 +241,11 @@ void V8::Initialize() {
 #if V8_ENABLE_WEBASSEMBLY
   wasm::WasmEngine::InitializeOncePerProcess();
 #endif  // V8_ENABLE_WEBASSEMBLY
+
+#ifdef V8_ENABLE_SANDBOX
+  IsolateGroup::current()->code_pointer_table()->Initialize();
+  IsolateGroup::current()->js_dispatch_table()->Initialize();
+#endif  // V8_ENABLE_SANDBOX
 
 #ifndef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
   ExternalReferenceTable::InitializeOncePerIsolateGroup(

--- a/src/objects/backing-store.cc
+++ b/src/objects/backing-store.cc
@@ -225,7 +225,7 @@ std::unique_ptr<BackingStore> BackingStore::Allocate(
     }
 #ifdef V8_ENABLE_SANDBOX
     // Check to catch use of a non-sandbox-compatible ArrayBufferAllocator.
-    CHECK_WITH_MSG(GetProcessWideSandbox()->Contains(buffer_start),
+    CHECK_WITH_MSG(Sandbox::current()->Contains(buffer_start),
                    "When the V8 Sandbox is enabled, ArrayBuffer backing stores "
                    "must be allocated inside the sandbox address space. Please "
                    "use an appropriate ArrayBuffer::Allocator to allocate "

--- a/src/objects/objects-inl.h
+++ b/src/objects/objects-inl.h
@@ -1116,7 +1116,7 @@ void HeapObject::AllocateAndInstallJSDispatchHandle(size_t offset,
                                                     Tagged<Code> code,
                                                     WriteBarrierMode mode) {
 #ifdef V8_ENABLE_LEAPTIERING
-  JSDispatchTable* jdt = GetProcessWideJSDispatchTable();
+  JSDispatchTable* jdt = IsolateGroup::current()->js_dispatch_table();
   JSDispatchTable::Space* space =
       isolate.GetJSDispatchTableSpaceFor(field_address(offset));
   JSDispatchHandle handle =

--- a/src/sandbox/js-dispatch-table.cc
+++ b/src/sandbox/js-dispatch-table.cc
@@ -67,9 +67,6 @@ void JSDispatchTable::InitializePreAllocatedEntry(Space* space,
 bool JSDispatchTable::IsMarked(JSDispatchHandle handle) {
   return at(HandleToIndex(handle)).IsMarked();
 }
-
-// Static
-std::atomic<bool> JSDispatchTable::initialized_ = false;
 #endif  // DEBUG
 
 void JSDispatchTable::PrintEntry(JSDispatchHandle handle) {
@@ -79,9 +76,6 @@ void JSDispatchTable::PrintEntry(JSDispatchHandle handle) {
   i::PrintF("* params %d\n", at(HandleToIndex(handle)).GetParameterCount());
   i::PrintF("* entrypoint 0x%lx\n", GetEntrypoint(handle));
 }
-
-// Static
-base::LeakyObject<JSDispatchTable> JSDispatchTable::instance_;
 
 }  // namespace internal
 }  // namespace v8

--- a/src/sandbox/sandbox.cc
+++ b/src/sandbox/sandbox.cc
@@ -25,6 +25,16 @@ namespace internal {
 
 #ifdef V8_ENABLE_SANDBOX
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+thread_local Sandbox* Sandbox::current_ = nullptr;
+// static
+Sandbox* Sandbox::current_non_inlined() { return current_; }
+// static
+void Sandbox::set_current_non_inlined(Sandbox* sandbox) {
+  current_ = sandbox;
+}
+#endif  // V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+
 // Best-effort function to determine the approximate size of the virtual
 // address space that can be addressed by this process. Used to determine
 // appropriate sandbox size and placement.
@@ -300,7 +310,11 @@ void Sandbox::TearDown() {
   }
 }
 
-DEFINE_LAZY_LEAKY_OBJECT_GETTER(Sandbox, GetProcessWideSandbox)
+Sandbox* GetDefaultSandbox() {
+  static base::LeakyObject<Sandbox> default_sandbox_;
+  return default_sandbox_.get();
+}
+
 
 #endif  // V8_ENABLE_SANDBOX
 

--- a/src/sandbox/sandbox.h
+++ b/src/sandbox/sandbox.h
@@ -198,6 +198,17 @@ class V8_EXPORT_PRIVATE Sandbox {
   Address end_address() const { return reinterpret_cast<Address>(&end_); }
   Address size_address() const { return reinterpret_cast<Address>(&size_); }
 
+  // Return true if we can create additional sandboxes: only the case if
+  // multiple pointer cages were configured in at build-time.
+  static constexpr bool CanCreateNewSandboxes() {
+    return COMPRESS_POINTERS_IN_MULTIPLE_CAGES_BOOL;
+  }
+
+  // Create a new sandbox allocating a fresh pointer cage.
+  // If new sandboxes cannot be created in this build configuration, abort.
+  //
+  static Sandbox* New();
+
 #ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
 #ifdef USING_V8_SHARED_PRIVATE
   static Sandbox* current() { return current_non_inlined(); }
@@ -209,7 +220,8 @@ class V8_EXPORT_PRIVATE Sandbox {
   static void set_current(Sandbox* sandbox) { current_ = sandbox; }
 #endif  // !USING_V8_SHARED_PRIVATE
 #else   // !V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
-  static Sandbox* current() { return GetDefaultSandbox(); }
+  static Sandbox* current() { return current_; }
+  static void set_current(Sandbox* sandbox) { current_ = sandbox; }
 #endif  // !V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
 
  private:
@@ -274,6 +286,8 @@ class V8_EXPORT_PRIVATE Sandbox {
 
 #ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
   thread_local static Sandbox* current_;
+#else
+  static Sandbox* current_;
 #endif  // V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
 };
 

--- a/src/sandbox/sandboxed-pointer-inl.h
+++ b/src/sandbox/sandboxed-pointer-inl.h
@@ -32,7 +32,7 @@ V8_INLINE void WriteSandboxedPointerField(Address field_address,
                                           Address pointer) {
 #ifdef V8_ENABLE_SANDBOX
   // The pointer must point into the sandbox.
-  CHECK(GetProcessWideSandbox()->Contains(pointer));
+  CHECK(Sandbox::current()->Contains(pointer));
 
   Address offset = pointer - cage_base.address();
   SandboxedPointer_t sandboxed_pointer = offset << kSandboxedPointerShift;

--- a/src/sandbox/testing.cc
+++ b/src/sandbox/testing.cc
@@ -41,14 +41,14 @@ namespace {
 void SandboxGetBase(const v8::FunctionCallbackInfo<v8::Value>& info) {
   DCHECK(ValidateCallbackInfo(info));
   v8::Isolate* isolate = info.GetIsolate();
-  double sandbox_base = GetProcessWideSandbox()->base();
+  double sandbox_base = Sandbox::current()->base();
   info.GetReturnValue().Set(v8::Number::New(isolate, sandbox_base));
 }
 // Sandbox.byteLength
 void SandboxGetByteLength(const v8::FunctionCallbackInfo<v8::Value>& info) {
   DCHECK(ValidateCallbackInfo(info));
   v8::Isolate* isolate = info.GetIsolate();
-  double sandbox_size = GetProcessWideSandbox()->size();
+  double sandbox_size = Sandbox::current()->size();
   info.GetReturnValue().Set(v8::Number::New(isolate, sandbox_size));
 }
 
@@ -70,7 +70,7 @@ void SandboxMemoryView(const v8::FunctionCallbackInfo<v8::Value>& info) {
     return;
   }
 
-  Sandbox* sandbox = GetProcessWideSandbox();
+  Sandbox* sandbox = Sandbox::current();
   CHECK_LE(sandbox->size(), kMaxSafeIntegerUint64);
 
   uint64_t offset = arg1->Value();
@@ -121,7 +121,7 @@ static bool GetArgumentObjectPassedAsReference(
 
 static bool GetArgumentObjectPassedAsAddress(
     const v8::FunctionCallbackInfo<v8::Value>& info, Tagged<HeapObject>* out) {
-  Sandbox* sandbox = GetProcessWideSandbox();
+  Sandbox* sandbox = Sandbox::current();
   v8::Isolate* isolate = info.GetIsolate();
   Local<v8::Context> context = isolate->GetCurrentContext();
 
@@ -476,7 +476,7 @@ void SandboxTesting::InstallMemoryCorruptionApiIfEnabled(Isolate* isolate) {
 
   if (!IsEnabled()) return;
 
-  CHECK(GetProcessWideSandbox()->is_initialized());
+  CHECK(Sandbox::current()->is_initialized());
 
   // Create the special Sandbox object that provides read/write access to the
   // sandbox address space alongside other miscellaneous functionality.
@@ -592,7 +592,7 @@ void CrashFilter(int signal, siginfo_t* info, void* void_context) {
 
   Address faultaddr = reinterpret_cast<Address>(info->si_addr);
 
-  if (GetProcessWideSandbox()->Contains(faultaddr)) {
+  if (Sandbox::current()->Contains(faultaddr)) {
     FilterCrash(
         "Caught harmless memory access violaton (inside sandbox address "
         "space). Exiting process...\n");
@@ -736,7 +736,7 @@ void AsanFaultHandler() {
         "check if it is a sandbox violation. Exiting process...\n");
   }
 
-  if (GetProcessWideSandbox()->Contains(faultaddr)) {
+  if (Sandbox::current()->Contains(faultaddr)) {
     FilterCrash(
         "Caught harmless ASan fault (inside sandbox address space). Exiting "
         "process...\n");
@@ -797,7 +797,7 @@ void InstallCrashFilter() {
 void SandboxTesting::Enable(Mode mode) {
   CHECK_EQ(mode_, Mode::kDisabled);
   CHECK_NE(mode, Mode::kDisabled);
-  CHECK(GetProcessWideSandbox()->is_initialized());
+  CHECK(Sandbox::current()->is_initialized());
 
   mode_ = mode;
 

--- a/src/sandbox/trusted-pointer-table-inl.h
+++ b/src/sandbox/trusted-pointer-table-inl.h
@@ -174,7 +174,7 @@ void TrustedPointerTable::Validate(Address pointer, IndirectPointerTag tag) {
     // This CHECK is mostly just here to force tags to be taken out of the
     // IsTrustedSpaceMigrationInProgressForObjectsWithTag function once the
     // objects are fully migrated into trusted space.
-    DCHECK(GetProcessWideSandbox()->Contains(pointer));
+    DCHECK(Sandbox::current()->Contains(pointer));
     return;
   }
 

--- a/src/snapshot/deserializer.cc
+++ b/src/snapshot/deserializer.cc
@@ -1466,7 +1466,7 @@ int Deserializer<IsolateT>::ReadAllocateJSDispatchEntry(
     uint8_t data, SlotAccessor slot_accessor) {
 #ifdef V8_ENABLE_LEAPTIERING
   DCHECK_NE(slot_accessor.object()->address(), kNullAddress);
-  JSDispatchTable* jdt = GetProcessWideJSDispatchTable();
+  JSDispatchTable* jdt = IsolateGroup::current()->js_dispatch_table();
   Handle<HeapObject> host = slot_accessor.object();
 
   uint32_t entry_id = source_.GetUint30();

--- a/src/snapshot/serializer.cc
+++ b/src/snapshot/serializer.cc
@@ -1261,7 +1261,7 @@ void Serializer::ObjectSerializer::VisitProtectedPointer(
 void Serializer::ObjectSerializer::VisitJSDispatchTableEntry(
     Tagged<HeapObject> host, JSDispatchHandle handle) {
 #ifdef V8_ENABLE_LEAPTIERING
-  JSDispatchTable* jdt = GetProcessWideJSDispatchTable();
+  JSDispatchTable* jdt = IsolateGroup::current()->js_dispatch_table();
   // If the slot is empty, we will skip it here and then just serialize the
   // null handle as raw data.
   if (handle == kNullJSDispatchHandle) return;

--- a/src/trap-handler/trap-handler.h
+++ b/src/trap-handler/trap-handler.h
@@ -57,6 +57,13 @@ namespace trap_handler {
 #define V8_TRAP_HANDLER_SUPPORTED false
 #endif
 
+// We can't setup process wide globals to handle traps when
+// there are many cages per process.
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+#undef V8_TRAP_HANDLER_SUPPORTED
+#define V8_TRAP_HANDLER_SUPPORTED false
+#endif  // V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+
 #if V8_OS_ANDROID && V8_TRAP_HANDLER_SUPPORTED
 // It would require some careful security review before the trap handler
 // can be enabled on Android.  Android may do unexpected things with signal

--- a/src/utils/allocation.cc
+++ b/src/utils/allocation.cc
@@ -80,8 +80,8 @@ v8::VirtualAddressSpace* GetPlatformVirtualAddressSpace() {
 
 #ifdef V8_ENABLE_SANDBOX
 v8::PageAllocator* GetSandboxPageAllocator() {
-  CHECK(GetProcessWideSandbox()->is_initialized());
-  return GetProcessWideSandbox()->page_allocator();
+  CHECK(Sandbox::current()->is_initialized());
+  return Sandbox::current()->page_allocator();
 }
 #endif
 

--- a/src/wasm/c-api.cc
+++ b/src/wasm/c-api.cc
@@ -942,9 +942,7 @@ class RefImpl {
   i::Isolate* isolate() const { return store()->i_isolate(); }
 
   i::Handle<JSType> v8_object() const {
-#ifdef DEBUG
     PtrComprCageAccessScope ptr_compr_cage_access_scope(isolate());
-#endif  // DEBUG
     return i::Cast<JSType>(val_);
   }
 

--- a/src/wasm/compilation-environment.h
+++ b/src/wasm/compilation-environment.h
@@ -148,7 +148,7 @@ class V8_EXPORT_PRIVATE CompilationState {
 
   CompilationState() = delete;
 
-  void InitCompileJob();
+  void InitCompileJob(IsolateGroup* isolate_group);
 
   void CancelCompilation();
 

--- a/src/wasm/wasm-code-manager.cc
+++ b/src/wasm/wasm-code-manager.cc
@@ -945,7 +945,8 @@ size_t WasmCodeAllocator::GetNumCodeSpaces() const {
   return owned_code_space_.size();
 }
 
-NativeModule::NativeModule(WasmEnabledFeatures enabled_features,
+NativeModule::NativeModule(IsolateGroup* isolate_group,
+                           WasmEnabledFeatures enabled_features,
                            WasmDetectedFeatures detected_features,
                            CompileTimeImports compile_imports,
                            DynamicTiering dynamic_tiering,
@@ -973,7 +974,7 @@ NativeModule::NativeModule(WasmEnabledFeatures enabled_features,
   compilation_state_ =
       CompilationState::New(*shared_this, std::move(async_counters),
                             dynamic_tiering, detected_features);
-  compilation_state_->InitCompileJob();
+  compilation_state_->InitCompileJob(isolate_group);
   DCHECK_NOT_NULL(module_);
   if (module_->num_declared_functions > 0) {
     code_table_ =
@@ -2487,8 +2488,8 @@ std::shared_ptr<NativeModule> WasmCodeManager::NewNativeModule(
   size_t size = code_space.size();
   Address end = code_space.end();
   std::shared_ptr<NativeModule> ret;
-  new NativeModule(enabled_features, detected_features,
-                   std::move(compile_imports),
+  new NativeModule(isolate->isolate_group(), enabled_features,
+                   detected_features, std::move(compile_imports),
                    DynamicTiering{v8_flags.wasm_dynamic_tiering.value()},
                    std::move(code_space), std::move(module),
                    isolate->async_counters(), &ret);

--- a/src/wasm/wasm-code-manager.h
+++ b/src/wasm/wasm-code-manager.h
@@ -919,7 +919,8 @@ class V8_EXPORT_PRIVATE NativeModule final {
   };
 
   // Private constructor, called via {WasmCodeManager::NewNativeModule()}.
-  NativeModule(WasmEnabledFeatures enabled_features,
+  NativeModule(IsolateGroup* isolate_group,
+               WasmEnabledFeatures enabled_features,
                WasmDetectedFeatures detected_features,
                CompileTimeImports compile_imports,
                DynamicTiering dynamic_tiering, VirtualMemory code_space,

--- a/test/cctest/cctest.status
+++ b/test/cctest/cctest.status
@@ -289,6 +289,13 @@
 }],  # 'full_debug'
 
 ##############################################################################
+['pointer_compression and not pointer_compression_shared_cage', {
+  # These tests require enabled trap handler but it is disabled for
+  # the multi-cage mode.
+  'test-run-wasm-simd/*': [SKIP],
+}],  # pointer_compression and not pointer_compression_shared_cage'
+
+##############################################################################
 ['byteorder == big', {
   # BUG(v8:12505). Tests which share Wasm memory buffer with Js Typed arrays.
   'test-api/WasmI32AtomicWaitCallback': [SKIP],

--- a/test/cctest/test-api.cc
+++ b/test/cctest/test-api.cc
@@ -13354,6 +13354,98 @@ UNINITIALIZED_TEST(SharedObjectGetConstructorName) {
   isolate->Dispose();
 }
 
+UNINITIALIZED_TEST(DefaultIsolateGroup) {
+  v8::IsolateGroup group1 = v8::IsolateGroup::GetDefault();
+  v8::IsolateGroup group2 = v8::IsolateGroup::GetDefault();
+
+  CHECK_EQ(group1, group2);
+
+  v8::Isolate::CreateParams create_params;
+  create_params.array_buffer_allocator = CcTest::array_buffer_allocator();
+
+  // Allocate() can control groups into which isolates are allocated.
+  for (int i = 0; i < 3; i++) {
+    v8::Isolate* isolate1 = v8::Isolate::Allocate(group1);
+    v8::Isolate* isolate1bis = v8::Isolate::Allocate(group1);
+    v8::Isolate* isolate2 = v8::Isolate::Allocate(group2);
+
+    CHECK_EQ(group1, isolate1->GetGroup());
+    CHECK_EQ(group1, isolate1bis->GetGroup());
+    CHECK_EQ(group2, isolate2->GetGroup());
+
+    // Have to initialize before disposing.
+    v8::Isolate::Initialize(isolate1, create_params);
+    v8::Isolate::Initialize(isolate1bis, create_params);
+    v8::Isolate::Initialize(isolate2, create_params);
+
+    isolate1->Dispose();
+    isolate1bis->Dispose();
+    isolate2->Dispose();
+  }
+
+  // New() can control groups into which isolates are allocated.
+  for (int i = 0; i < 3; i++) {
+    v8::Isolate* isolate1 = v8::Isolate::New(group1, create_params);
+    v8::Isolate* isolate1bis = v8::Isolate::New(group1, create_params);
+    v8::Isolate* isolate2 = v8::Isolate::New(group2, create_params);
+
+    CHECK_EQ(group1, isolate1->GetGroup());
+    CHECK_EQ(group1, isolate1bis->GetGroup());
+    CHECK_EQ(group2, isolate2->GetGroup());
+
+    isolate1->Dispose();
+    isolate1bis->Dispose();
+    isolate2->Dispose();
+  }
+}
+
+UNINITIALIZED_TEST(MultipleIsolateGroups) {
+  if (!v8::IsolateGroup::CanCreateNewGroups()) return;
+  
+  v8::IsolateGroup group1 = v8::IsolateGroup::Create();
+  v8::IsolateGroup group2 = v8::IsolateGroup::Create();
+
+  CHECK_NE(group1, group2);
+
+  v8::Isolate::CreateParams create_params;
+  create_params.array_buffer_allocator = CcTest::array_buffer_allocator();
+
+  // Allocate() can control groups into which isolates are allocated.
+  for (int i = 0; i < 3; i++) {
+    v8::Isolate* isolate1 = v8::Isolate::Allocate(group1);
+    v8::Isolate* isolate1bis = v8::Isolate::Allocate(group1);
+    v8::Isolate* isolate2 = v8::Isolate::Allocate(group2);
+
+    CHECK_EQ(group1, isolate1->GetGroup());
+    CHECK_EQ(group1, isolate1bis->GetGroup());
+    CHECK_EQ(group2, isolate2->GetGroup());
+
+    // Have to initialize before disposing.
+    v8::Isolate::Initialize(isolate1, create_params);
+    v8::Isolate::Initialize(isolate1bis, create_params);
+    v8::Isolate::Initialize(isolate2, create_params);
+
+    isolate1->Dispose();
+    isolate1bis->Dispose();
+    isolate2->Dispose();
+  }
+
+  // New() can control groups into which isolates are allocated.
+  for (int i = 0; i < 3; i++) {
+    v8::Isolate* isolate1 = v8::Isolate::New(group1, create_params);
+    v8::Isolate* isolate1bis = v8::Isolate::New(group1, create_params);
+    v8::Isolate* isolate2 = v8::Isolate::New(group2, create_params);
+
+    CHECK_EQ(group1, isolate1->GetGroup());
+    CHECK_EQ(group1, isolate1bis->GetGroup());
+    CHECK_EQ(group2, isolate2->GetGroup());
+
+    isolate1->Dispose();
+    isolate1bis->Dispose();
+    isolate2->Dispose();
+  }
+}
+
 unsigned ApiTestFuzzer::linear_congruential_generator;
 std::vector<std::unique_ptr<ApiTestFuzzer>> ApiTestFuzzer::fuzzers_;
 bool ApiTestFuzzer::fuzzing_ = false;

--- a/test/cctest/test-ptr-compr-cage.cc
+++ b/test/cctest/test-ptr-compr-cage.cc
@@ -24,11 +24,7 @@ UNINITIALIZED_TEST(PtrComprCageAndIsolateRoot) {
 
 #ifdef V8_COMPRESS_POINTERS
   CHECK_NE(i_isolate1->isolate_root(), i_isolate2->isolate_root());
-#ifdef V8_COMPRESS_POINTERS_IN_SHARED_CAGE
   CHECK_EQ(i_isolate1->cage_base(), i_isolate2->cage_base());
-#else
-  CHECK_NE(i_isolate1->cage_base(), i_isolate2->cage_base());
-#endif  // V8_COMPRESS_POINTERS_IN_SHARED_CAGE
 #endif  // V8_COMPRESS_POINTERS
 
   isolate1->Dispose();

--- a/test/fuzzer/inspector-fuzzer.cc
+++ b/test/fuzzer/inspector-fuzzer.cc
@@ -18,6 +18,7 @@
 #include "src/base/platform/time.h"
 #include "src/base/small-vector.h"
 #include "src/base/vector.h"
+#include "src/sandbox/sandbox.h"
 #include "test/inspector/frontend-channel.h"
 #include "test/inspector/isolate-data.h"
 #include "test/inspector/task-runner.h"
@@ -596,7 +597,12 @@ void FuzzInspector(const uint8_t* data, size_t size) {
   frontend_extensions.emplace_back(new UtilsExtension());
   TaskRunner frontend_runner(std::move(frontend_extensions),
                              kSuppressUncaughtExceptions, &ready_semaphore,
-                             nullptr, kNoInspector);
+                             nullptr, kNoInspector
+#if V8_ENABLE_SANDBOX && V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+                             ,
+                             Sandbox::current()
+#endif
+  );
   ready_semaphore.Wait();
 
   int frontend_context_group_id = 0;
@@ -610,7 +616,12 @@ void FuzzInspector(const uint8_t* data, size_t size) {
   backend_extensions.emplace_back(new InspectorExtension());
   TaskRunner backend_runner(std::move(backend_extensions),
                             kSuppressUncaughtExceptions, &ready_semaphore,
-                            nullptr, kWithInspector);
+                            nullptr, kWithInspector
+#if V8_ENABLE_SANDBOX && V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+                            ,
+                            Sandbox::current()
+#endif
+  );
   ready_semaphore.Wait();
   UtilsExtension::set_backend_task_runner(&backend_runner);
 

--- a/test/inspector/inspector-test.cc
+++ b/test/inspector/inspector-test.cc
@@ -16,6 +16,7 @@
 #include "src/base/platform/platform.h"
 #include "src/base/small-vector.h"
 #include "src/flags/flags.h"
+#include "src/sandbox/sandbox.h"
 #include "src/utils/utils.h"
 #include "test/inspector/frontend-channel.h"
 #include "test/inspector/isolate-data.h"
@@ -874,7 +875,12 @@ int InspectorTestMain(int argc, char* argv[]) {
     TaskRunner frontend_runner(std::move(frontend_extensions),
                                kFailOnUncaughtExceptions, &ready_semaphore,
                                startup_data.data ? &startup_data : nullptr,
-                               kNoInspector);
+                               kNoInspector
+#if V8_ENABLE_SANDBOX && V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+                               ,
+                               Sandbox::current()
+#endif
+    );
     ready_semaphore.Wait();
 
     int frontend_context_group_id = 0;
@@ -890,7 +896,12 @@ int InspectorTestMain(int argc, char* argv[]) {
     TaskRunner backend_runner(
         std::move(backend_extensions), kStandardPropagateUncaughtExceptions,
         &ready_semaphore, startup_data.data ? &startup_data : nullptr,
-        kWithInspector);
+        kWithInspector
+#if V8_ENABLE_SANDBOX && V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+        ,
+        Sandbox::current()
+#endif
+    );
     ready_semaphore.Wait();
     UtilsExtension::set_backend_task_runner(&backend_runner);
 

--- a/test/inspector/task-runner.h
+++ b/test/inspector/task-runner.h
@@ -36,7 +36,12 @@ class TaskRunner : public v8::base::Thread {
   TaskRunner(InspectorIsolateData::SetupGlobalTasks setup_global_tasks,
              CatchExceptions catch_exceptions,
              v8::base::Semaphore* ready_semaphore,
-             v8::StartupData* startup_data, WithInspector with_inspector);
+             v8::StartupData* startup_data, WithInspector with_inspector
+#if V8_ENABLE_SANDBOX && V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+             ,
+             Sandbox* sandbox
+#endif
+  );
   ~TaskRunner() override;
   TaskRunner(const TaskRunner&) = delete;
   TaskRunner& operator=(const TaskRunner&) = delete;
@@ -74,6 +79,9 @@ class TaskRunner : public v8::base::Thread {
 
   int nested_loop_count_;
   std::atomic<int> is_terminated_;
+#if V8_ENABLE_SANDBOX && V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  Sandbox* sandbox_;
+#endif
 };
 
 }  // namespace internal

--- a/test/unittests/heap/cppgc/ephemeron-pair-unittest.cc
+++ b/test/unittests/heap/cppgc/ephemeron-pair-unittest.cc
@@ -10,6 +10,7 @@
 #include "src/heap/cppgc/heap-object-header.h"
 #include "src/heap/cppgc/marking-visitor.h"
 #include "src/heap/cppgc/stats-collector.h"
+#include "src/init/isolate-group.h"
 #include "test/unittests/heap/cppgc/tests.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -68,8 +69,9 @@ class EphemeronPairTest : public testing::TestWithHeap {
   }
 
   void InitializeMarker(HeapBase& heap, cppgc::Platform* platform) {
-    marker_ = std::make_unique<Marker>(heap, platform,
-                                       IncrementalPreciseMarkingConfig);
+    marker_ =
+        std::make_unique<Marker>(v8::internal::IsolateGroup::current(), heap,
+                                 platform, IncrementalPreciseMarkingConfig);
     marker_->StartMarking();
   }
 

--- a/test/unittests/heap/cppgc/marker-unittest.cc
+++ b/test/unittests/heap/cppgc/marker-unittest.cc
@@ -16,6 +16,7 @@
 #include "src/heap/cppgc/marking-visitor.h"
 #include "src/heap/cppgc/object-allocator.h"
 #include "src/heap/cppgc/stats-collector.h"
+#include "src/init/isolate-group.h"
 #include "test/unittests/heap/cppgc/tests.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -38,7 +39,8 @@ class MarkerTest : public testing::TestWithHeap {
 
   void InitializeMarker(HeapBase& heap, cppgc::Platform* platform,
                         MarkingConfig config) {
-    marker_ = std::make_unique<Marker>(heap, platform, config);
+    marker_ = std::make_unique<Marker>(v8::internal::IsolateGroup::current(),
+                                       heap, platform, config);
     marker_->StartMarking();
   }
 
@@ -410,7 +412,8 @@ class IncrementalMarkingTest : public testing::TestWithHeap {
 
   void InitializeMarker(HeapBase& heap, cppgc::Platform* platform,
                         MarkingConfig config) {
-    GetMarkerRef() = std::make_unique<Marker>(heap, platform, config);
+    GetMarkerRef() = std::make_unique<Marker>(
+        v8::internal::IsolateGroup::current(), heap, platform, config);
     GetMarkerRef()->StartMarking();
   }
 

--- a/test/unittests/heap/cppgc/marking-visitor-unittest.cc
+++ b/test/unittests/heap/cppgc/marking-visitor-unittest.cc
@@ -12,6 +12,7 @@
 #include "src/heap/cppgc/heap-object-header.h"
 #include "src/heap/cppgc/marker.h"
 #include "src/heap/cppgc/marking-state.h"
+#include "src/init/isolate-group.h"
 #include "test/unittests/heap/cppgc/tests.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -23,7 +24,8 @@ namespace {
 class MarkingVisitorTest : public testing::TestWithHeap {
  public:
   MarkingVisitorTest()
-      : marker_(std::make_unique<Marker>(*Heap::From(GetHeap()),
+      : marker_(std::make_unique<Marker>(v8::internal::IsolateGroup::current(),
+                                         *Heap::From(GetHeap()),
                                          GetPlatformHandle().get())) {
     marker_->StartMarking();
   }

--- a/test/unittests/heap/cppgc/stats-collector-scopes-unittest.cc
+++ b/test/unittests/heap/cppgc/stats-collector-scopes-unittest.cc
@@ -6,6 +6,7 @@
 
 #include "src/heap/cppgc/heap-config.h"
 #include "src/heap/cppgc/stats-collector.h"
+#include "src/init/isolate-group.h"
 #include "test/unittests/heap/cppgc/tests.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -67,7 +68,8 @@ class V8_NODISCARD CppgcTracingScopesTest : public testing::TestWithHeap {
     MarkingConfig config = {CollectionType::kMajor, StackState::kNoHeapPointers,
                             GCConfig::MarkingType::kIncremental};
     GetMarkerRef() = std::make_unique<Marker>(
-        Heap::From(GetHeap())->AsBase(), GetPlatformHandle().get(), config);
+        v8::internal::IsolateGroup::current(), Heap::From(GetHeap())->AsBase(),
+        GetPlatformHandle().get(), config);
     GetMarkerRef()->StartMarking();
     DelegatingTracingControllerImpl::check_expectations = true;
   }

--- a/test/unittests/heap/cppgc/weak-container-unittest.cc
+++ b/test/unittests/heap/cppgc/weak-container-unittest.cc
@@ -9,6 +9,7 @@
 #include "src/heap/cppgc/marker.h"
 #include "src/heap/cppgc/marking-visitor.h"
 #include "src/heap/cppgc/stats-collector.h"
+#include "src/init/isolate-group.h"
 #include "test/unittests/heap/cppgc/tests.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -24,7 +25,8 @@ class WeakContainerTest : public testing::TestWithHeap {
     MarkingConfig config = {CollectionType::kMajor, StackState::kNoHeapPointers,
                             MarkingConfig::MarkingType::kIncremental};
     GetMarkerRef() = std::make_unique<Marker>(
-        Heap::From(GetHeap())->AsBase(), GetPlatformHandle().get(), config);
+        v8::internal::IsolateGroup::current(), Heap::From(GetHeap())->AsBase(),
+        GetPlatformHandle().get(), config);
     GetMarkerRef()->StartMarking();
   }
 

--- a/test/unittests/heap/cppgc/write-barrier-unittest.cc
+++ b/test/unittests/heap/cppgc/write-barrier-unittest.cc
@@ -13,6 +13,7 @@
 #include "src/base/logging.h"
 #include "src/heap/cppgc/heap-object-header.h"
 #include "src/heap/cppgc/marker.h"
+#include "src/init/isolate-group.h"
 #include "test/unittests/heap/cppgc/tests.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -161,9 +162,9 @@ class WriteBarrierTest : public testing::TestWithHeap {
  public:
   WriteBarrierTest() : internal_heap_(Heap::From(GetHeap())) {
     DCHECK_NULL(GetMarkerRef().get());
-    GetMarkerRef() =
-        std::make_unique<Marker>(*internal_heap_, GetPlatformHandle().get(),
-                                 IncrementalMarkingScope::kIncrementalConfig);
+    GetMarkerRef() = std::make_unique<Marker>(
+        v8::internal::IsolateGroup::current(), *internal_heap_,
+        GetPlatformHandle().get(), IncrementalMarkingScope::kIncrementalConfig);
     marker_ = GetMarkerRef().get();
     marker_->StartMarking();
   }

--- a/test/unittests/heap/pool-unittest.cc
+++ b/test/unittests/heap/pool-unittest.cc
@@ -301,10 +301,6 @@ class PoolTest : public                                     //
   PoolTest(const PoolTest&) = delete;
   PoolTest& operator=(const PoolTest&) = delete;
 
-  static void FreeProcessWidePtrComprCageForTesting() {
-    IsolateGroup::ReleaseGlobal();
-  }
-
   static void DoMixinSetUp() {
     CHECK_NULL(tracking_page_allocator_);
     old_page_allocator_ = GetPlatformPageAllocator();
@@ -314,11 +310,7 @@ class PoolTest : public                                     //
              SetPlatformPageAllocatorForTesting(tracking_page_allocator_));
     old_sweeping_flag_ = i::v8_flags.concurrent_sweeping;
     i::v8_flags.concurrent_sweeping = false;
-#ifndef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
-    // Reinitialize the process-wide pointer cage so it can pick up the
-    // TrackingPageAllocator.
-    // The pointer cage must be destroyed before the sandbox.
-    FreeProcessWidePtrComprCageForTesting();
+    IsolateGroup::ReleaseDefault();
 #ifdef V8_ENABLE_SANDBOX
     // Reinitialze the sandbox so it uses the TrackingPageAllocator.
     GetProcessWideSandbox()->TearDown();
@@ -327,15 +319,10 @@ class PoolTest : public                                     //
         tracking_page_allocator_, kSandboxMinimumSize, use_guard_regions));
 #endif
     IsolateGroup::InitializeOncePerProcess();
-#endif
   }
 
   static void DoMixinTearDown() {
-#ifndef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
-    // Free the process-wide cage reservation, otherwise the pages won't be
-    // freed until process teardown.
-    FreeProcessWidePtrComprCageForTesting();
-#endif
+    IsolateGroup::ReleaseDefault();
 #ifdef V8_ENABLE_SANDBOX
     GetProcessWideSandbox()->TearDown();
 #endif

--- a/test/unittests/heap/pool-unittest.cc
+++ b/test/unittests/heap/pool-unittest.cc
@@ -313,9 +313,9 @@ class PoolTest : public                                     //
     IsolateGroup::ReleaseDefault();
 #ifdef V8_ENABLE_SANDBOX
     // Reinitialze the sandbox so it uses the TrackingPageAllocator.
-    GetProcessWideSandbox()->TearDown();
+    Sandbox::current()->TearDown();
     constexpr bool use_guard_regions = false;
-    CHECK(GetProcessWideSandbox()->Initialize(
+    CHECK(Sandbox::current()->Initialize(
         tracking_page_allocator_, kSandboxMinimumSize, use_guard_regions));
 #endif
     IsolateGroup::InitializeOncePerProcess();
@@ -324,7 +324,7 @@ class PoolTest : public                                     //
   static void DoMixinTearDown() {
     IsolateGroup::ReleaseDefault();
 #ifdef V8_ENABLE_SANDBOX
-    GetProcessWideSandbox()->TearDown();
+    Sandbox::current()->TearDown();
 #endif
     i::v8_flags.concurrent_sweeping = old_sweeping_flag_;
     CHECK(tracking_page_allocator_->IsEmpty());


### PR DESCRIPTION
When ArrayBuffer backings are freed through the
BackendAllocator we should use the same VitualAddressSpace that was used to allocate the backings.  This lets us free from a different thread without holding the V8 lock.