### PR TITLE
Fast isolate cloning stable

### DIFF
--- a/include/v8-platform.h
+++ b/include/v8-platform.h
@@ -1038,12 +1038,21 @@ class VirtualAddressSpace {
    * \param key Optional memory protection key for the subspace. If used, the
    * returned subspace will use this key for all its memory pages.
    *
+   * \param handle Optional file descriptor for the subspace. If used, the
+   * returned subspace will use this file description with 0 offset as the
+   * space's underlying file.
+   *
+   * \param is_shared If true the reservation for the subspace will be
+   * allocated with shared mappings.
+   *
    * \returns a new subspace or nullptr on failure.
    */
   virtual std::unique_ptr<VirtualAddressSpace> AllocateSubspace(
       Address hint, size_t size, size_t alignment,
       PagePermissions max_page_permissions,
-      std::optional<MemoryProtectionKeyId> key = std::nullopt) = 0;
+      std::optional<MemoryProtectionKeyId> key = std::nullopt,
+      PlatformSharedMemoryHandle handle = kInvalidSharedMemoryHandle,
+      bool is_shared = false) = 0;
 
   //
   // TODO(v8) maybe refactor the methods below before stabilizing the API. For

--- a/src/base/emulated-virtual-address-subspace.cc
+++ b/src/base/emulated-virtual-address-subspace.cc
@@ -174,7 +174,8 @@ std::unique_ptr<v8::VirtualAddressSpace>
 EmulatedVirtualAddressSubspace::AllocateSubspace(
     Address hint, size_t size, size_t alignment,
     PagePermissions max_page_permissions,
-    std::optional<MemoryProtectionKeyId> key) {
+    std::optional<MemoryProtectionKeyId> key, PlatformSharedMemoryHandle handle,
+    bool is_shared) {
   UNIMPLEMENTED();
 }
 

--- a/src/base/emulated-virtual-address-subspace.h
+++ b/src/base/emulated-virtual-address-subspace.h
@@ -73,7 +73,9 @@ class V8_BASE_EXPORT EmulatedVirtualAddressSubspace final
   std::unique_ptr<v8::VirtualAddressSpace> AllocateSubspace(
       Address hint, size_t size, size_t alignment,
       PagePermissions max_page_permissions,
-      std::optional<MemoryProtectionKeyId> key) override;
+      std::optional<MemoryProtectionKeyId> key = std::nullopt,
+      PlatformSharedMemoryHandle handle = kInvalidSharedMemoryHandle,
+      bool is_shared = false) override;
 
   bool RecommitPages(Address address, size_t size,
                      PagePermissions permissions) override;

--- a/src/base/platform/platform-fuchsia.cc
+++ b/src/base/platform/platform-fuchsia.cc
@@ -266,7 +266,7 @@ void OS::Initialize(AbortMode abort_mode, const char* const gc_fake_mmap) {
 
 // static
 void* OS::Allocate(void* address, size_t size, size_t alignment,
-                   MemoryPermission access) {
+                   MemoryPermission access, PlatformSharedMemoryHandle handle) {
   PlacementMode placement =
       address != nullptr ? PlacementMode::kUseHint : PlacementMode::kAnywhere;
   return CreateAndMapVmo(*zx::vmar::root_self(), g_root_vmar_base,
@@ -337,8 +337,8 @@ bool OS::CanReserveAddressSpace() { return true; }
 
 // static
 std::optional<AddressSpaceReservation> OS::CreateAddressSpaceReservation(
-    void* hint, size_t size, size_t alignment,
-    MemoryPermission max_permission) {
+    void* hint, size_t size, size_t alignment, MemoryPermission max_permission,
+    PlatformSharedMemoryHandle handle, bool is_shared) {
   DCHECK_EQ(0, reinterpret_cast<Address>(hint) % alignment);
   zx::vmar child;
   zx_vaddr_t child_addr;

--- a/src/base/platform/platform-posix.cc
+++ b/src/base/platform/platform-posix.cc
@@ -117,15 +117,6 @@ DEFINE_LAZY_LEAKY_OBJECT_GETTER(RandomNumberGenerator,
 static LazyMutex rng_mutex = LAZY_MUTEX_INITIALIZER;
 
 #if !V8_OS_FUCHSIA && !V8_OS_ZOS
-#if V8_OS_DARWIN
-// kMmapFd is used to pass vm_alloc flags to tag the region with the user
-// defined tag 255 This helps identify V8-allocated regions in memory analysis
-// tools like vmmap(1).
-const int kMmapFd = VM_MAKE_TAG(255);
-#else   // !V8_OS_DARWIN
-const int kMmapFd = -1;
-#endif  // !V8_OS_DARWIN
-
 #if defined(V8_TARGET_OS_MACOS) && V8_HOST_ARCH_ARM64
 // During snapshot generation in cross builds, sysconf() runs on the Intel
 // host and returns host page size, while the snapshot needs to use the
@@ -137,9 +128,16 @@ const int kMmapFdOffset = 0;
 
 enum class PageType { kShared, kPrivate };
 
-int GetFlagsForMemoryPermission(OS::MemoryPermission access,
-                                PageType page_type) {
-  int flags = MAP_ANONYMOUS;
+int GetFlagsForMemoryPermission(OS::MemoryPermission access, PageType page_type,
+                                PlatformSharedMemoryHandle handle,
+                                bool fixed = false) {
+  int flags = 0;
+  if (handle == kInvalidSharedMemoryHandle) {
+    flags |= MAP_ANONYMOUS;
+  }
+  if (fixed) {
+    flags |= MAP_FIXED;
+  }
   flags |= (page_type == PageType::kShared) ? MAP_SHARED : MAP_PRIVATE;
   if (access == OS::MemoryPermission::kNoAccess ||
       access == OS::MemoryPermission::kNoAccessWillJitLater) {
@@ -164,10 +162,13 @@ int GetFlagsForMemoryPermission(OS::MemoryPermission access,
 }
 
 void* Allocate(void* hint, size_t size, OS::MemoryPermission access,
-               PageType page_type) {
+               PageType page_type,
+               PlatformSharedMemoryHandle handle = kInvalidSharedMemoryHandle,
+               bool fixed = false) {
   int prot = GetProtectionFromMemoryPermission(access);
-  int flags = GetFlagsForMemoryPermission(access, page_type);
-  void* result = mmap(hint, size, prot, flags, kMmapFd, kMmapFdOffset);
+  int flags = GetFlagsForMemoryPermission(access, page_type, handle, fixed);
+  int fd = FileDescriptorFromSharedMemoryHandle(handle);
+  void* result = mmap(hint, size, prot, flags, fd, kMmapFdOffset);
   if (result == MAP_FAILED) return nullptr;
 
 #if V8_OS_LINUX && V8_ENABLE_PRIVATE_MAPPING_FORK_OPTIMIZATION
@@ -457,7 +458,8 @@ void* OS::GetRandomMmapAddr() {
 #if !V8_OS_ZOS
 // static
 void* OS::Allocate(void* hint, size_t size, size_t alignment,
-                   MemoryPermission access) {
+                   MemoryPermission access, PlatformSharedMemoryHandle handle,
+                   bool is_shared) {
   size_t page_size = AllocatePageSize();
   DCHECK_EQ(0, size % page_size);
   DCHECK_EQ(0, alignment % page_size);
@@ -465,7 +467,8 @@ void* OS::Allocate(void* hint, size_t size, size_t alignment,
   // Add the maximum misalignment so we are guaranteed an aligned base address.
   size_t request_size = size + (alignment - page_size);
   request_size = RoundUp(request_size, OS::AllocatePageSize());
-  void* result = base::Allocate(hint, request_size, access, PageType::kPrivate);
+  PageType page_type = is_shared ? PageType::kShared : PageType::kPrivate;
+  void* result = base::Allocate(hint, request_size, access, page_type, handle);
   if (result == nullptr) return nullptr;
 
   // Unmap memory allocated before the aligned base address.
@@ -487,6 +490,17 @@ void* OS::Allocate(void* hint, size_t size, size_t alignment,
   }
 
   DCHECK_EQ(size, request_size);
+
+  if (aligned_base != base && handle != kInvalidSharedMemoryHandle) {
+    // We have to remap because the base of mapping
+    // must correspond to the base of the the underlying file.
+    uint8_t* new_base = reinterpret_cast<uint8_t*>(base::Allocate(
+        aligned_base, size, access, page_type, handle, true /* fixed */));
+    if (new_base != aligned_base) {
+      return nullptr;
+    }
+  }
+
   return static_cast<void*>(aligned_base);
 }
 
@@ -675,19 +689,21 @@ bool OS::CanReserveAddressSpace() { return true; }
 
 // static
 std::optional<AddressSpaceReservation> OS::CreateAddressSpaceReservation(
-    void* hint, size_t size, size_t alignment,
-    MemoryPermission max_permission) {
+    void* hint, size_t size, size_t alignment, MemoryPermission max_permission,
+    PlatformSharedMemoryHandle handle, bool is_shared) {
   // On POSIX, address space reservations are backed by private memory mappings.
   MemoryPermission permission = MemoryPermission::kNoAccess;
   if (max_permission == MemoryPermission::kReadWriteExecute) {
     permission = MemoryPermission::kNoAccessWillJitLater;
   }
 
-  void* reservation = Allocate(hint, size, alignment, permission);
+  void* reservation =
+      Allocate(hint, size, alignment, permission, handle, is_shared);
   if (!reservation && permission == MemoryPermission::kNoAccessWillJitLater) {
     // Retry without MAP_JIT, for example in case we are running on an old OS X.
     permission = MemoryPermission::kNoAccess;
-    reservation = Allocate(hint, size, alignment, permission);
+    reservation =
+        Allocate(hint, size, alignment, permission, handle, is_shared);
   }
 
   if (!reservation) return {};

--- a/src/base/platform/platform-win32.cc
+++ b/src/base/platform/platform-win32.cc
@@ -995,7 +995,8 @@ void CheckIsOOMError(int error) {
 
 // static
 void* OS::Allocate(void* hint, size_t size, size_t alignment,
-                   MemoryPermission access) {
+                   MemoryPermission access, PlatformSharedMemoryHandle handle,
+                   bool is_shared) {
   size_t page_size = AllocatePageSize();
   DCHECK_EQ(0, size % page_size);
   DCHECK_EQ(0, alignment % page_size);
@@ -1138,8 +1139,8 @@ bool OS::CanReserveAddressSpace() {
 
 // static
 std::optional<AddressSpaceReservation> OS::CreateAddressSpaceReservation(
-    void* hint, size_t size, size_t alignment,
-    MemoryPermission max_permission) {
+    void* hint, size_t size, size_t alignment, MemoryPermission max_permission,
+    PlatformSharedMemoryHandle handle, bool is_shared) {
   CHECK(CanReserveAddressSpace());
 
   size_t page_size = AllocatePageSize();

--- a/src/base/platform/platform.h
+++ b/src/base/platform/platform.h
@@ -382,9 +382,10 @@ class V8_BASE_EXPORT OS {
 
   static void* GetRandomMmapAddr();
 
-  V8_WARN_UNUSED_RESULT static void* Allocate(void* address, size_t size,
-                                              size_t alignment,
-                                              MemoryPermission access);
+  V8_WARN_UNUSED_RESULT static void* Allocate(
+      void* address, size_t size, size_t alignment, MemoryPermission access,
+      PlatformSharedMemoryHandle handle = kInvalidSharedMemoryHandle,
+      bool is_shared = false);
 
   V8_WARN_UNUSED_RESULT static void* AllocateShared(size_t size,
                                                     MemoryPermission access);
@@ -419,8 +420,11 @@ class V8_BASE_EXPORT OS {
   V8_WARN_UNUSED_RESULT static bool CanReserveAddressSpace();
 
   V8_WARN_UNUSED_RESULT static std::optional<AddressSpaceReservation>
-  CreateAddressSpaceReservation(void* hint, size_t size, size_t alignment,
-                                MemoryPermission max_permission);
+  CreateAddressSpaceReservation(
+      void* hint, size_t size, size_t alignment,
+      MemoryPermission max_permission,
+      PlatformSharedMemoryHandle handle = kInvalidSharedMemoryHandle,
+      bool is_shared = false);
 
   static void FreeAddressSpaceReservation(AddressSpaceReservation reservation);
 

--- a/src/base/sanitizer/lsan-virtual-address-space.cc
+++ b/src/base/sanitizer/lsan-virtual-address-space.cc
@@ -65,9 +65,10 @@ void LsanVirtualAddressSpace::FreeSharedPages(Address address, size_t size) {
 std::unique_ptr<VirtualAddressSpace> LsanVirtualAddressSpace::AllocateSubspace(
     Address hint, size_t size, size_t alignment,
     PagePermissions max_page_permissions,
-    std::optional<MemoryProtectionKeyId> key) {
-  auto subspace =
-      vas_->AllocateSubspace(hint, size, alignment, max_page_permissions, key);
+    std::optional<MemoryProtectionKeyId> key, PlatformSharedMemoryHandle handle,
+    bool is_shared) {
+  auto subspace = vas_->AllocateSubspace(
+      hint, size, alignment, max_page_permissions, key, handle, is_shared);
 #if defined(LEAK_SANITIZER)
   if (subspace) {
     subspace = std::make_unique<LsanVirtualAddressSpace>(std::move(subspace));

--- a/src/base/sanitizer/lsan-virtual-address-space.h
+++ b/src/base/sanitizer/lsan-virtual-address-space.h
@@ -70,7 +70,9 @@ class V8_BASE_EXPORT LsanVirtualAddressSpace final
   std::unique_ptr<VirtualAddressSpace> AllocateSubspace(
       Address hint, size_t size, size_t alignment,
       PagePermissions max_page_permissions,
-      std::optional<MemoryProtectionKeyId> key) override;
+      std::optional<MemoryProtectionKeyId> key = std::nullopt,
+      PlatformSharedMemoryHandle handle = kInvalidSharedMemoryHandle,
+      bool is_shared = false) override;
 
   bool DiscardSystemPages(Address address, size_t size) override {
     return vas_->DiscardSystemPages(address, size);

--- a/src/base/virtual-address-space.cc
+++ b/src/base/virtual-address-space.cc
@@ -148,7 +148,8 @@ void VirtualAddressSpace::FreeSharedPages(Address address, size_t size) {
 std::unique_ptr<v8::VirtualAddressSpace> VirtualAddressSpace::AllocateSubspace(
     Address hint, size_t size, size_t alignment,
     PagePermissions max_page_permissions,
-    std::optional<MemoryProtectionKeyId> key) {
+    std::optional<MemoryProtectionKeyId> key, PlatformSharedMemoryHandle handle,
+    bool is_shared) {
   DCHECK(IsAligned(alignment, allocation_granularity()));
   DCHECK(IsAligned(hint, alignment));
   DCHECK(IsAligned(size, allocation_granularity()));
@@ -156,7 +157,8 @@ std::unique_ptr<v8::VirtualAddressSpace> VirtualAddressSpace::AllocateSubspace(
   std::optional<AddressSpaceReservation> reservation =
       OS::CreateAddressSpaceReservation(
           reinterpret_cast<void*>(hint), size, alignment,
-          static_cast<OS::MemoryPermission>(max_page_permissions));
+          static_cast<OS::MemoryPermission>(max_page_permissions), handle,
+          is_shared);
   if (!reservation.has_value())
     return std::unique_ptr<v8::VirtualAddressSpace>();
   return std::unique_ptr<v8::VirtualAddressSpace>(new VirtualAddressSubspace(
@@ -377,7 +379,10 @@ std::unique_ptr<v8::VirtualAddressSpace>
 VirtualAddressSubspace::AllocateSubspace(
     Address hint, size_t size, size_t alignment,
     PagePermissions max_page_permissions,
-    std::optional<MemoryProtectionKeyId> key) {
+    std::optional<MemoryProtectionKeyId> key, PlatformSharedMemoryHandle handle,
+    bool is_shared) {
+  // File backed mapping isn't supported for subspaces.
+  DCHECK_EQ(handle, kInvalidSharedMemoryHandle);
 #if V8_HAS_PKU_SUPPORT
   // We don't allow subspaces with different keys as that could be unexpected.
   // If we ever want to support this, we should probably require specifying

--- a/src/base/virtual-address-space.h
+++ b/src/base/virtual-address-space.h
@@ -84,7 +84,9 @@ class V8_BASE_EXPORT VirtualAddressSpace : public VirtualAddressSpaceBase {
   std::unique_ptr<v8::VirtualAddressSpace> AllocateSubspace(
       Address hint, size_t size, size_t alignment,
       PagePermissions max_page_permissions,
-      std::optional<MemoryProtectionKeyId> key = std::nullopt) override;
+      std::optional<MemoryProtectionKeyId> key = std::nullopt,
+      PlatformSharedMemoryHandle handle = kInvalidSharedMemoryHandle,
+      bool is_shared = false) override;
 
   bool RecommitPages(Address address, size_t size,
                      PagePermissions access) override;
@@ -135,7 +137,9 @@ class V8_BASE_EXPORT VirtualAddressSubspace : public VirtualAddressSpaceBase {
   std::unique_ptr<v8::VirtualAddressSpace> AllocateSubspace(
       Address hint, size_t size, size_t alignment,
       PagePermissions max_page_permissions,
-      std::optional<MemoryProtectionKeyId> key = std::nullopt) override;
+      std::optional<MemoryProtectionKeyId> key = std::nullopt,
+      PlatformSharedMemoryHandle handle = kInvalidSharedMemoryHandle,
+      bool is_shared = false) override;
 
   bool RecommitPages(Address address, size_t size,
                      PagePermissions permissions) override;

--- a/src/sandbox/sandbox.h
+++ b/src/sandbox/sandbox.h
@@ -83,7 +83,9 @@ class V8_EXPORT_PRIVATE Sandbox {
    * address space can be allocated for even a partially-reserved sandbox, then
    * this method will fail with an OOM crash.
    */
-  void Initialize(v8::VirtualAddressSpace* vas);
+  void Initialize(v8::VirtualAddressSpace* vas,
+                  PlatformSharedMemoryHandle underlying_memory_file =
+                      kInvalidSharedMemoryHandle);
 
   /**
    * Tear down this sandbox.
@@ -239,6 +241,14 @@ class V8_EXPORT_PRIVATE Sandbox {
   static Sandbox* New(v8::VirtualAddressSpace* vas);
 
 #ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  /**
+   * Create a clone of the whole sandbox.
+   *
+   * The resulted clone will use copy-on-write
+   * copy of the original sandbox.
+   */
+  Sandbox* Clone(v8::VirtualAddressSpace* vas);
+
 #ifdef USING_V8_SHARED_PRIVATE
   static Sandbox* current() { return current_non_inlined(); }
   static void set_current(Sandbox* sandbox) {
@@ -273,7 +283,9 @@ class V8_EXPORT_PRIVATE Sandbox {
   // subspaces. The size must be a multiple of the allocation granularity of the
   // virtual memory space.
   bool Initialize(v8::VirtualAddressSpace* vas, size_t size,
-                  bool use_guard_regions);
+                  bool use_guard_regions,
+                  PlatformSharedMemoryHandle underlying_memory_file =
+                      kInvalidSharedMemoryHandle);
 
   // Used when reserving virtual memory is too expensive. A partially reserved
   // sandbox does not reserve all of its virtual memory and so doesn't have the
@@ -330,6 +342,8 @@ class V8_EXPORT_PRIVATE Sandbox {
   static bool first_four_gb_of_address_space_are_reserved_;
 
 #ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  PlatformSharedMemoryHandle underlying_memory_file_ =
+      kInvalidSharedMemoryHandle;
   thread_local static Sandbox* current_;
 #endif  // V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
 };


### PR DESCRIPTION
Fast isolate cloning, part I: Introduce Sandbox::clone method.

To support copy-on-write (CoW) cloning, each sandbox is backed by an in-memory file (e.g., via memfd_create). 
The original instance maps this file with MAP_SHARED to populate it. Clones are then created by mapping the same file with MAP_PRIVATE, which provides CoW semantics.