### PR TITLE
Part 1: Introduce Sandbox::clone method

### DIFF
--- a/include/v8-platform.h
+++ b/include/v8-platform.h
@@ -1042,13 +1042,17 @@ class VirtualAddressSpace {
    * returned subspace will use this file descriptor with 0 offset as the
    * space's underlying file.
    *
+   * \param is_shared If true the reservation for the subspace will be
+   * allocated as a shared mapping.
+   *
    * \returns a new subspace or nullptr on failure.
    */
   virtual std::unique_ptr<VirtualAddressSpace> AllocateSubspace(
       Address hint, size_t size, size_t alignment,
       PagePermissions max_page_permissions,
       std::optional<MemoryProtectionKeyId> key = std::nullopt,
-      PlatformSharedMemoryHandle handle = kInvalidSharedMemoryHandle) = 0;
+      PlatformSharedMemoryHandle handle = kInvalidSharedMemoryHandle,
+      bool is_shared = false) = 0;
 
   //
   // TODO(v8) maybe refactor the methods below before stabilizing the API. For

--- a/src/base/emulated-virtual-address-subspace.cc
+++ b/src/base/emulated-virtual-address-subspace.cc
@@ -174,8 +174,8 @@ std::unique_ptr<v8::VirtualAddressSpace>
 EmulatedVirtualAddressSubspace::AllocateSubspace(
     Address hint, size_t size, size_t alignment,
     PagePermissions max_page_permissions,
-    std::optional<MemoryProtectionKeyId> key,
-    PlatformSharedMemoryHandle handle) {
+    std::optional<MemoryProtectionKeyId> key, PlatformSharedMemoryHandle handle,
+    bool is_shared) {
   UNIMPLEMENTED();
 }
 

--- a/src/base/emulated-virtual-address-subspace.h
+++ b/src/base/emulated-virtual-address-subspace.h
@@ -74,7 +74,8 @@ class V8_BASE_EXPORT EmulatedVirtualAddressSubspace final
       Address hint, size_t size, size_t alignment,
       PagePermissions max_page_permissions,
       std::optional<MemoryProtectionKeyId> key = std::nullopt,
-      PlatformSharedMemoryHandle handle = kInvalidSharedMemoryHandle) override;
+      PlatformSharedMemoryHandle handle = kInvalidSharedMemoryHandle,
+      bool is_shared = false) override;
 
   bool RecommitPages(Address address, size_t size,
                      PagePermissions permissions) override;

--- a/src/base/platform/platform-fuchsia.cc
+++ b/src/base/platform/platform-fuchsia.cc
@@ -266,7 +266,8 @@ void OS::Initialize(const char* const gc_fake_mmap) {
 
 // static
 void* OS::Allocate(void* address, size_t size, size_t alignment,
-                   MemoryPermission access, PlatformSharedMemoryHandle handle) {
+                   MemoryPermission access, PlatformSharedMemoryHandle handle,
+                   bool is_shared) {
   // File handles aren't supported.
   DCHECK_EQ(handle, kInvalidSharedMemoryHandle);
   PlacementMode placement =
@@ -340,7 +341,7 @@ bool OS::CanReserveAddressSpace() { return true; }
 // static
 std::optional<AddressSpaceReservation> OS::CreateAddressSpaceReservation(
     void* hint, size_t size, size_t alignment, MemoryPermission max_permission,
-    PlatformSharedMemoryHandle handle) {
+    PlatformSharedMemoryHandle handle, bool is_shared) {
   DCHECK_EQ(0, reinterpret_cast<Address>(hint) % alignment);
   zx::vmar child;
   zx_vaddr_t child_addr;

--- a/src/base/platform/platform-posix.cc
+++ b/src/base/platform/platform-posix.cc
@@ -463,7 +463,8 @@ void* OS::GetRandomMmapAddr() {
 #if !V8_OS_ZOS
 // static
 void* OS::Allocate(void* hint, size_t size, size_t alignment,
-                   MemoryPermission access, PlatformSharedMemoryHandle handle) {
+                   MemoryPermission access, PlatformSharedMemoryHandle handle,
+                   bool is_shared) {
   size_t page_size = AllocatePageSize();
   DCHECK_EQ(0, size % page_size);
   DCHECK_EQ(0, alignment % page_size);
@@ -471,7 +472,7 @@ void* OS::Allocate(void* hint, size_t size, size_t alignment,
   // Add the maximum misalignment so we are guaranteed an aligned base address.
   size_t request_size = size + (alignment - page_size);
   request_size = RoundUp(request_size, OS::AllocatePageSize());
-  PageType page_type = PageType::kPrivate;
+  PageType page_type = is_shared ? PageType::kShared : PageType::kPrivate;
   void* result = base::Allocate(hint, request_size, access, page_type, handle);
   if (result == nullptr) return nullptr;
 
@@ -694,18 +695,20 @@ bool OS::CanReserveAddressSpace() { return true; }
 // static
 std::optional<AddressSpaceReservation> OS::CreateAddressSpaceReservation(
     void* hint, size_t size, size_t alignment, MemoryPermission max_permission,
-    PlatformSharedMemoryHandle handle) {
+    PlatformSharedMemoryHandle handle, bool is_shared) {
   // On POSIX, address space reservations are backed by private memory mappings.
   MemoryPermission permission = MemoryPermission::kNoAccess;
   if (max_permission == MemoryPermission::kReadWriteExecute) {
     permission = MemoryPermission::kNoAccessWillJitLater;
   }
 
-  void* reservation = Allocate(hint, size, alignment, permission, handle);
+  void* reservation =
+      Allocate(hint, size, alignment, permission, handle, is_shared);
   if (!reservation && permission == MemoryPermission::kNoAccessWillJitLater) {
     // Retry without MAP_JIT, for example in case we are running on an old OS X.
     permission = MemoryPermission::kNoAccess;
-    reservation = Allocate(hint, size, alignment, permission, handle);
+    reservation =
+        Allocate(hint, size, alignment, permission, handle, is_shared);
   }
 
   if (!reservation) return {};

--- a/src/base/platform/platform-win32.cc
+++ b/src/base/platform/platform-win32.cc
@@ -995,7 +995,8 @@ void CheckIsOOMError(int error) {
 
 // static
 void* OS::Allocate(void* hint, size_t size, size_t alignment,
-                   MemoryPermission access, PlatformSharedMemoryHandle handle) {
+                   MemoryPermission access, PlatformSharedMemoryHandle handle,
+                   bool is_shared) {
   // File handles aren't supported.
   DCHECK_EQ(handle, kInvalidSharedMemoryHandle);
 
@@ -1142,7 +1143,7 @@ bool OS::CanReserveAddressSpace() {
 // static
 std::optional<AddressSpaceReservation> OS::CreateAddressSpaceReservation(
     void* hint, size_t size, size_t alignment, MemoryPermission max_permission,
-    PlatformSharedMemoryHandle handle) {
+    PlatformSharedMemoryHandle handle, bool is_shared) {
   // File handles aren't supported.
   DCHECK_EQ(handle, kInvalidSharedMemoryHandle);
   CHECK(CanReserveAddressSpace());

--- a/src/base/platform/platform.h
+++ b/src/base/platform/platform.h
@@ -383,7 +383,8 @@ class V8_BASE_EXPORT OS {
 
   V8_WARN_UNUSED_RESULT static void* Allocate(
       void* address, size_t size, size_t alignment, MemoryPermission access,
-      PlatformSharedMemoryHandle handle = kInvalidSharedMemoryHandle);
+      PlatformSharedMemoryHandle handle = kInvalidSharedMemoryHandle,
+      bool is_shared = false);
 
   V8_WARN_UNUSED_RESULT static void* AllocateShared(size_t size,
                                                     MemoryPermission access);
@@ -421,7 +422,8 @@ class V8_BASE_EXPORT OS {
   CreateAddressSpaceReservation(
       void* hint, size_t size, size_t alignment,
       MemoryPermission max_permission,
-      PlatformSharedMemoryHandle handle = kInvalidSharedMemoryHandle);
+      PlatformSharedMemoryHandle handle = kInvalidSharedMemoryHandle,
+      bool is_shared = false);
 
   static void FreeAddressSpaceReservation(AddressSpaceReservation reservation);
 

--- a/src/base/sanitizer/lsan-virtual-address-space.cc
+++ b/src/base/sanitizer/lsan-virtual-address-space.cc
@@ -65,10 +65,10 @@ void LsanVirtualAddressSpace::FreeSharedPages(Address address, size_t size) {
 std::unique_ptr<VirtualAddressSpace> LsanVirtualAddressSpace::AllocateSubspace(
     Address hint, size_t size, size_t alignment,
     PagePermissions max_page_permissions,
-    std::optional<MemoryProtectionKeyId> key,
-    PlatformSharedMemoryHandle handle) {
-  auto subspace = vas_->AllocateSubspace(hint, size, alignment,
-                                         max_page_permissions, key, handle);
+    std::optional<MemoryProtectionKeyId> key, PlatformSharedMemoryHandle handle,
+    bool is_shared) {
+  auto subspace = vas_->AllocateSubspace(
+      hint, size, alignment, max_page_permissions, key, handle, is_shared);
 #if defined(LEAK_SANITIZER)
   if (subspace) {
     subspace = std::make_unique<LsanVirtualAddressSpace>(std::move(subspace));

--- a/src/base/sanitizer/lsan-virtual-address-space.h
+++ b/src/base/sanitizer/lsan-virtual-address-space.h
@@ -71,7 +71,8 @@ class V8_BASE_EXPORT LsanVirtualAddressSpace final
       Address hint, size_t size, size_t alignment,
       PagePermissions max_page_permissions,
       std::optional<MemoryProtectionKeyId> key = std::nullopt,
-      PlatformSharedMemoryHandle handle = kInvalidSharedMemoryHandle) override;
+      PlatformSharedMemoryHandle handle = kInvalidSharedMemoryHandle,
+      bool is_shared = false) override;
 
   bool DiscardSystemPages(Address address, size_t size) override {
     return vas_->DiscardSystemPages(address, size);

--- a/src/base/virtual-address-space.cc
+++ b/src/base/virtual-address-space.cc
@@ -148,8 +148,8 @@ void VirtualAddressSpace::FreeSharedPages(Address address, size_t size) {
 std::unique_ptr<v8::VirtualAddressSpace> VirtualAddressSpace::AllocateSubspace(
     Address hint, size_t size, size_t alignment,
     PagePermissions max_page_permissions,
-    std::optional<MemoryProtectionKeyId> key,
-    PlatformSharedMemoryHandle handle) {
+    std::optional<MemoryProtectionKeyId> key, PlatformSharedMemoryHandle handle,
+    bool is_shared) {
   DCHECK(IsAligned(alignment, allocation_granularity()));
   DCHECK(IsAligned(hint, alignment));
   DCHECK(IsAligned(size, allocation_granularity()));
@@ -157,7 +157,8 @@ std::unique_ptr<v8::VirtualAddressSpace> VirtualAddressSpace::AllocateSubspace(
   std::optional<AddressSpaceReservation> reservation =
       OS::CreateAddressSpaceReservation(
           reinterpret_cast<void*>(hint), size, alignment,
-          static_cast<OS::MemoryPermission>(max_page_permissions), handle);
+          static_cast<OS::MemoryPermission>(max_page_permissions), handle,
+          is_shared);
   if (!reservation.has_value())
     return std::unique_ptr<v8::VirtualAddressSpace>();
   return std::unique_ptr<v8::VirtualAddressSpace>(new VirtualAddressSubspace(
@@ -378,8 +379,8 @@ std::unique_ptr<v8::VirtualAddressSpace>
 VirtualAddressSubspace::AllocateSubspace(
     Address hint, size_t size, size_t alignment,
     PagePermissions max_page_permissions,
-    std::optional<MemoryProtectionKeyId> key,
-    PlatformSharedMemoryHandle handle) {
+    std::optional<MemoryProtectionKeyId> key, PlatformSharedMemoryHandle handle,
+    bool is_shared) {
   // File backed mapping isn't supported for subspaces.
   DCHECK_EQ(handle, kInvalidSharedMemoryHandle);
 #if V8_HAS_PKU_SUPPORT

--- a/src/base/virtual-address-space.h
+++ b/src/base/virtual-address-space.h
@@ -85,7 +85,8 @@ class V8_BASE_EXPORT VirtualAddressSpace : public VirtualAddressSpaceBase {
       Address hint, size_t size, size_t alignment,
       PagePermissions max_page_permissions,
       std::optional<MemoryProtectionKeyId> key = std::nullopt,
-      PlatformSharedMemoryHandle handle = kInvalidSharedMemoryHandle) override;
+      PlatformSharedMemoryHandle handle = kInvalidSharedMemoryHandle,
+      bool is_shared = false) override;
 
   bool RecommitPages(Address address, size_t size,
                      PagePermissions access) override;
@@ -137,7 +138,8 @@ class V8_BASE_EXPORT VirtualAddressSubspace : public VirtualAddressSpaceBase {
       Address hint, size_t size, size_t alignment,
       PagePermissions max_page_permissions,
       std::optional<MemoryProtectionKeyId> key = std::nullopt,
-      PlatformSharedMemoryHandle handle = kInvalidSharedMemoryHandle) override;
+      PlatformSharedMemoryHandle handle = kInvalidSharedMemoryHandle,
+      bool is_shared = false) override;
 
   bool RecommitPages(Address address, size_t size,
                      PagePermissions permissions) override;

--- a/src/sandbox/sandbox.h
+++ b/src/sandbox/sandbox.h
@@ -83,7 +83,9 @@ class V8_EXPORT_PRIVATE Sandbox {
    * address space can be allocated for even a partially-reserved sandbox, then
    * this method will fail with an OOM crash.
    */
-  void Initialize(v8::VirtualAddressSpace* vas);
+  void Initialize(v8::VirtualAddressSpace* vas,
+                  PlatformSharedMemoryHandle underlying_memory_file =
+                      kInvalidSharedMemoryHandle);
 
   /**
    * Tear down this sandbox.
@@ -239,6 +241,14 @@ class V8_EXPORT_PRIVATE Sandbox {
   static Sandbox* New(v8::VirtualAddressSpace* vas);
 
 #ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  /**
+   * Create a clone of the whole sandbox.
+   *
+   * The resulted clone will use copy-on-write
+   * copy of the original sandbox.
+   */
+  Sandbox* Clone(v8::VirtualAddressSpace* vas);
+
 #ifdef USING_V8_SHARED_PRIVATE
   static Sandbox* current() { return current_non_inlined(); }
   static void set_current(Sandbox* sandbox) {
@@ -273,7 +283,9 @@ class V8_EXPORT_PRIVATE Sandbox {
   // subspaces. The size must be a multiple of the allocation granularity of the
   // virtual memory space.
   bool Initialize(v8::VirtualAddressSpace* vas, size_t size,
-                  bool use_guard_regions);
+                  bool use_guard_regions,
+                  PlatformSharedMemoryHandle underlying_memory_file =
+                      kInvalidSharedMemoryHandle);
 
   // Used when reserving virtual memory is too expensive. A partially reserved
   // sandbox does not reserve all of its virtual memory and so doesn't have the
@@ -330,6 +342,8 @@ class V8_EXPORT_PRIVATE Sandbox {
   static bool first_four_gb_of_address_space_are_reserved_;
 
 #ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  PlatformSharedMemoryHandle underlying_memory_file_ =
+      kInvalidSharedMemoryHandle;
   thread_local static Sandbox* current_;
 #endif  // V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
 };


### PR DESCRIPTION
To support copy-on-write (CoW) cloning, each sandbox is backed by an in-memory file (via memfd_create).
The original instance maps this file with MAP_SHARED to populate it. Clones are then created by mapping the same file with MAP_PRIVATE, which provides CoW semantics.
