### PR TITLE
Part 2: Share code and trusted cages

### DIFF
--- a/include/v8-platform.h
+++ b/include/v8-platform.h
@@ -21,6 +21,10 @@ namespace v8 {
 
 class Isolate;
 
+// Opaque type representing a handle to a shared memory region.
+using PlatformSharedMemoryHandle = intptr_t;
+static constexpr PlatformSharedMemoryHandle kInvalidSharedMemoryHandle = -1;
+
 // Valid priorities supported by the task scheduling infrastructure.
 enum class TaskPriority : uint8_t {
   /**
@@ -542,6 +546,17 @@ class PageAllocator {
   }
 
   /**
+   * Allocates pages with specifying underlying file.
+   */
+  virtual void* AllocateFileBackedPages(void* address, size_t length,
+                                        size_t alignment,
+                                        Permission permissions,
+                                        PlatformSharedMemoryHandle handle,
+                                        bool is_private) {
+    return nullptr;
+  }
+
+  /**
    * Resizes the previously allocated memory at the given address. Returns true
    * if the allocation could be resized. Returns false if this operation is
    * either not supported or the object could not be resized in-place.
@@ -702,10 +717,6 @@ class ThreadIsolatedAllocator {
    */
   virtual int Pkey() const { return -1; }
 };
-
-// Opaque type representing a handle to a shared memory region.
-using PlatformSharedMemoryHandle = intptr_t;
-static constexpr PlatformSharedMemoryHandle kInvalidSharedMemoryHandle = -1;
 
 // Conversion routines from the platform-dependent shared memory identifiers
 // into the opaque PlatformSharedMemoryHandle type. These use the underlying

--- a/src/base/page-allocator.cc
+++ b/src/base/page-allocator.cc
@@ -56,6 +56,17 @@ void* PageAllocator::AllocatePages(void* hint, size_t size, size_t alignment,
                             static_cast<base::OS::MemoryPermission>(access));
 }
 
+void* PageAllocator::AllocateFileBackedPages(void* hint, size_t size,
+                                             size_t alignment,
+                                             Permission access,
+                                             PlatformSharedMemoryHandle handle,
+                                             bool is_private) {
+  return base::OS::Allocate(hint, size, alignment,
+                            static_cast<base::OS::MemoryPermission>(access),
+                            handle,
+                            /* shareable */ !is_private);
+}
+
 class SharedMemoryMapping : public ::v8::PageAllocator::SharedMemoryMapping {
  public:
   explicit SharedMemoryMapping(PageAllocator* page_allocator, void* ptr,

--- a/src/base/page-allocator.h
+++ b/src/base/page-allocator.h
@@ -33,6 +33,11 @@ class V8_BASE_EXPORT PageAllocator
   void* AllocatePages(void* hint, size_t size, size_t alignment,
                       PageAllocator::Permission access) override;
 
+  void* AllocateFileBackedPages(void* hint, size_t length, size_t alignment,
+                                PageAllocator::Permission access,
+                                PlatformSharedMemoryHandle handle,
+                                bool is_private) override;
+
   bool CanAllocateSharedPages() override;
 
   std::unique_ptr<v8::PageAllocator::SharedMemory> AllocateSharedPages(

--- a/src/base/platform/platform-posix.cc
+++ b/src/base/platform/platform-posix.cc
@@ -726,7 +726,8 @@ void OS::FreeAddressSpaceReservation(AddressSpaceReservation reservation) {
 // static
 // Need to disable CFI_ICALL due to the indirect call to memfd_create.
 DISABLE_CFI_ICALL
-PlatformSharedMemoryHandle OS::CreateSharedMemoryHandleForTesting(size_t size) {
+PlatformSharedMemoryHandle OS::CreateSharedMemoryHandleForTesting(
+    size_t size, const char* name) {
 #if V8_OS_LINUX && !V8_OS_ANDROID
   // Use memfd_create if available, otherwise mkstemp.
   using memfd_create_t = int (*)(const char*, unsigned int);
@@ -734,7 +735,7 @@ PlatformSharedMemoryHandle OS::CreateSharedMemoryHandleForTesting(size_t size) {
       reinterpret_cast<memfd_create_t>(dlsym(RTLD_DEFAULT, "memfd_create"));
   int fd = -1;
   if (memfd_create) {
-    fd = memfd_create("V8MemFDForTesting", 0);
+    fd = memfd_create(name == nullptr ? "V8MemFDForTesting" : name, 0);
   }
   if (fd == -1) {
     char filename[] = "/tmp/v8_tmp_file_for_testing_XXXXXX";

--- a/src/base/platform/platform.h
+++ b/src/base/platform/platform.h
@@ -229,7 +229,7 @@ class V8_BASE_EXPORT OS {
 
   // Helpers to create shared memory objects. Currently only used for testing.
   static PlatformSharedMemoryHandle CreateSharedMemoryHandleForTesting(
-      size_t size);
+      size_t size, const char* name = nullptr);
   static void DestroySharedMemoryHandle(PlatformSharedMemoryHandle handle);
 
   static bool HasLazyCommits();

--- a/src/common/ptr-compr-inl.h
+++ b/src/common/ptr-compr-inl.h
@@ -221,6 +221,9 @@ Address ExternalCodeCompressionScheme::DecompressTagged(Tagged_t raw_value) {
   DCHECK_WITH_MSG(cage_base != kNullAddress,
                   "ExternalCodeCompressionScheme::base is not initialized for "
                   "current thread");
+
+  // For multi-cage mode code cage is 4Gb aligned.
+  DCHECK_EQ(static_cast<uint32_t>(cage_base), 0u);
 #endif  // V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
   V8_ASSUME((cage_base & kMinExpectedOSPageSizeMask) == cage_base);
 
@@ -231,6 +234,10 @@ Address ExternalCodeCompressionScheme::DecompressTagged(Tagged_t raw_value) {
   // the decompressed value is off by 4GB.
   if (static_cast<intptr_t>(diff) < 0) {
     diff += size_t{4} * GB;
+
+    // It can't happen because code cage is 4Gb aligned
+    // in multi-cage configuration.
+    DCHECK(!COMPRESS_POINTERS_IN_MULTIPLE_CAGES_BOOL);
   }
   DCHECK(is_uint32(diff));
   Address result = cage_base + diff;

--- a/src/heap/code-range.cc
+++ b/src/heap/code-range.cc
@@ -149,7 +149,8 @@ size_t CodeRange::GetWritableReservedAreaSize() {
   if (v8_flags.trace_code_range_allocation) PrintF(__VA_ARGS__)
 
 bool CodeRange::InitReservation(v8::PageAllocator* page_allocator,
-                                size_t requested, bool immutable) {
+                                size_t requested, bool immutable,
+                                CodeRange* original) {
   DCHECK_NE(requested, 0);
   if (V8_EXTERNAL_CODE_SPACE_BOOL) {
     page_allocator = GetPlatformPageAllocator();
@@ -263,10 +264,36 @@ bool CodeRange::InitReservation(v8::PageAllocator* page_allocator,
 #endif
     // Last resort, use whatever region we could get with minimum constraints.
     params.requested_start_hint = the_hint;
-    if (!VirtualMemoryCage::InitReservation(params)) {
-      params.requested_start_hint = kNullAddress;
-      if (!VirtualMemoryCage::InitReservation(params)) return false;
+    auto init_reservation_helper =
+        [&params, this](PlatformSharedMemoryHandle file, bool is_private) {
+          if (VirtualMemoryCage::InitReservation(params, file, is_private))
+            return true;
+          params.requested_start_hint = kNullAddress;
+          return VirtualMemoryCage::InitReservation(params, file, is_private);
+        };
+
+    PlatformSharedMemoryHandle file = kInvalidSharedMemoryHandle;
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+    if (original) {
+      // Allocate code cage CoW clone.
+      file = original->underlying_memory_file_;
+    } else {
+      // Allocate shareable code cage.
+      underlying_memory_file_ =
+          v8::base::OS::CreateSharedMemoryHandleForTesting(
+              params.reservation_size, "code cage");
+      file = underlying_memory_file_;
     }
+#endif
+
+    const bool is_private =
+        COMPRESS_POINTERS_IN_SHARED_CAGE_BOOL || original != nullptr;
+    DCHECK_IMPLIES(COMPRESS_POINTERS_IN_SHARED_CAGE_BOOL,
+                   file == kInvalidSharedMemoryHandle);
+    if (!init_reservation_helper(file, is_private)) {
+      return false;
+    }
+
     TRACE("=== Fallback attempt, hint=%p: [%p, %p)\n",
           reinterpret_cast<void*>(params.requested_start_hint),
           reinterpret_cast<void*>(region().begin()),

--- a/src/heap/code-range.cc
+++ b/src/heap/code-range.cc
@@ -169,8 +169,15 @@ bool CodeRange::InitReservation(v8::PageAllocator* page_allocator,
   VirtualMemoryCage::ReservationParams params;
   params.page_allocator = page_allocator;
   params.reservation_size = requested;
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  // To share code cage between two isolate groups
+  // we have to use 4GB alignment to make addresses
+  // to code cage base independent.
+  params.base_alignment = size_t{4} * GB;
+#else
   params.base_alignment =
       VirtualMemoryCage::ReservationParams::kAnyBaseAlignment;
+#endif
   params.page_size = kPageSize;
   if (v8_flags.jitless) {
     params.permissions = PageAllocator::Permission::kNoAccess;
@@ -251,6 +258,9 @@ bool CodeRange::InitReservation(v8::PageAllocator* page_allocator,
   if (!IsReserved()) {
     Address the_hint = GetCodeRangeAddressHint()->GetAddressHint(
         requested, allocate_page_size);
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+    the_hint = RoundUp(the_hint, params.base_alignment);
+#endif
     // Last resort, use whatever region we could get with minimum constraints.
     params.requested_start_hint = the_hint;
     if (!VirtualMemoryCage::InitReservation(params)) {

--- a/src/heap/code-range.h
+++ b/src/heap/code-range.h
@@ -144,7 +144,7 @@ class CodeRange final : public VirtualMemoryCage {
   // flag specifies if the reservation will live until the end of the process
   // and can be sealed.
   bool InitReservation(v8::PageAllocator* page_allocator, size_t requested,
-                       bool immutable);
+                       bool immutable, CodeRange* original = nullptr);
 
   V8_EXPORT_PRIVATE void Free();
 
@@ -179,6 +179,11 @@ class CodeRange final : public VirtualMemoryCage {
 
 #if !defined(V8_OS_WIN) && !defined(V8_OS_IOS) && defined(DEBUG)
   bool immutable_ = false;
+#endif
+
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  PlatformSharedMemoryHandle underlying_memory_file_ =
+      kInvalidSharedMemoryHandle;
 #endif
 };
 

--- a/src/heap/trusted-range.cc
+++ b/src/heap/trusted-range.cc
@@ -12,7 +12,7 @@ namespace internal {
 
 #ifdef V8_ENABLE_SANDBOX
 
-bool TrustedRange::InitReservation(size_t requested) {
+bool TrustedRange::InitReservation(size_t requested, TrustedRange* original) {
   DCHECK_LE(requested, kMaximalTrustedRangeSize);
   DCHECK_GE(requested, kMinimumTrustedRangeSize);
 
@@ -49,7 +49,24 @@ bool TrustedRange::InitReservation(size_t requested) {
   params.page_initialization_mode =
       base::PageInitializationMode::kAllocatedPagesCanBeUninitialized;
   params.page_freeing_mode = base::PageFreeingMode::kMakeInaccessible;
-  bool success = VirtualMemoryCage::InitReservation(params);
+
+  PlatformSharedMemoryHandle underlying_file = kInvalidSharedMemoryHandle;
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  if (original) {
+    // Allocate trusted cage CoW clone.
+    underlying_file = original->underlying_memory_file_;
+  } else {
+    // Allocate shareable trusted cage.
+    underlying_memory_file_ = v8::base::OS::CreateSharedMemoryHandleForTesting(
+        params.reservation_size, "trusted cage");
+    underlying_file = underlying_memory_file_;
+  }
+#endif
+
+  const bool is_private =
+      COMPRESS_POINTERS_IN_SHARED_CAGE_BOOL || original != nullptr;
+  bool success =
+      VirtualMemoryCage::InitReservation(params, underlying_file, is_private);
 
   if (success) {
     // Reserve the null page to mitigate (compressed) nullptr dereference bugs.

--- a/src/heap/trusted-range.h
+++ b/src/heap/trusted-range.h
@@ -21,7 +21,12 @@ namespace internal {
 // reference objects. We have one trusted range per isolate group.
 class TrustedRange final : public VirtualMemoryCage {
  public:
-  bool InitReservation(size_t requested);
+  bool InitReservation(size_t requested, TrustedRange* original = nullptr);
+
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  PlatformSharedMemoryHandle underlying_memory_file_ =
+      kInvalidSharedMemoryHandle;
+#endif
 };
 
 #endif  // V8_ENABLE_SANDBOX

--- a/src/utils/allocation.cc
+++ b/src/utils/allocation.cc
@@ -183,6 +183,27 @@ void* AllocatePages(v8::PageAllocator* page_allocator, size_t size,
   return result;
 }
 
+void* AllocatePages(v8::PageAllocator* page_allocator, size_t size,
+                    size_t alignment, PageAllocator::Permission access,
+                    PageAllocator::AllocationHint hint,
+                    PlatformSharedMemoryHandle handle, bool is_private) {
+  DCHECK_NOT_NULL(page_allocator);
+  DCHECK(IsAligned(reinterpret_cast<Address>(hint.Address()), alignment));
+  DCHECK(IsAligned(size, page_allocator->AllocatePageSize()));
+  if (!hint.Address() && v8_flags.randomize_all_allocations) {
+    hint = hint.WithAddress(
+        AlignedAddress(page_allocator->GetRandomMmapAddr(), alignment));
+  }
+  void* result = nullptr;
+  for (int i = 0; i < kAllocationTries; ++i) {
+    result = page_allocator->AllocateFileBackedPages(
+        hint.Address(), size, alignment, access, handle, is_private);
+    if (V8_LIKELY(result != nullptr)) break;
+    OnCriticalMemoryPressure();
+  }
+  return result;
+}
+
 void FreePages(v8::PageAllocator* page_allocator, void* address,
                const size_t size) {
   DCHECK_NOT_NULL(page_allocator);
@@ -226,6 +247,25 @@ VirtualMemory::VirtualMemory(v8::PageAllocator* page_allocator, size_t size,
   alignment = RoundUp(alignment, page_size);
   Address address = reinterpret_cast<Address>(AllocatePages(
       page_allocator_, RoundUp(size, page_size), alignment, permissions, hint));
+  if (address != kNullAddress) {
+    DCHECK(IsAligned(address, alignment));
+    region_ = base::AddressRegion(address, size);
+  }
+}
+
+VirtualMemory::VirtualMemory(PlatformSharedMemoryHandle handle, bool is_private,
+                             v8::PageAllocator* page_allocator, size_t size,
+                             PageAllocator::AllocationHint hint,
+                             size_t alignment,
+                             PageAllocator::Permission permissions)
+    : page_allocator_(page_allocator) {
+  DCHECK_NOT_NULL(page_allocator);
+  DCHECK(IsAligned(size, page_allocator_->CommitPageSize()));
+  const size_t page_size = page_allocator_->AllocatePageSize();
+  alignment = RoundUp(alignment, page_size);
+  Address address = reinterpret_cast<Address>(
+      AllocatePages(page_allocator_, RoundUp(size, page_size), alignment,
+                    permissions, hint, handle, is_private));
   if (address != kNullAddress) {
     DCHECK(IsAligned(address, alignment));
     region_ = base::AddressRegion(address, size);
@@ -359,6 +399,46 @@ bool VirtualMemoryCage::InitReservation(
     base_ = reservation_.address();
     CHECK_EQ(reservation_.size(), params.reservation_size);
   }
+  CHECK_NE(base_, kNullAddress);
+  CHECK(IsAligned(base_, params.base_alignment));
+
+  const Address allocatable_base = RoundUp(base_, params.page_size);
+  const size_t allocatable_size = RoundDown(
+      params.reservation_size - (allocatable_base - base_), params.page_size);
+  size_ = allocatable_base + allocatable_size - base_;
+
+  page_allocator_ = std::make_unique<base::BoundedPageAllocator>(
+      params.page_allocator, allocatable_base, allocatable_size,
+      params.page_size, params.page_initialization_mode,
+      params.page_freeing_mode);
+  return true;
+}
+
+bool VirtualMemoryCage::InitReservation(
+    const ReservationParams& params,
+    PlatformSharedMemoryHandle underlying_memory_file, bool is_private) {
+  DCHECK(!reservation_.IsReserved());
+
+  const size_t allocate_page_size = params.page_allocator->AllocatePageSize();
+  CHECK(IsAligned(params.reservation_size, allocate_page_size));
+  CHECK(params.base_alignment == ReservationParams::kAnyBaseAlignment ||
+        IsAligned(params.base_alignment, allocate_page_size));
+
+  Address hint = params.requested_start_hint;
+  // Require the hint to be properly aligned because here it's not clear
+  // anymore whether it should be rounded up or down.
+  CHECK(IsAligned(hint, params.base_alignment));
+  VirtualMemory reservation(underlying_memory_file, is_private,
+                            params.page_allocator, params.reservation_size,
+                            v8::PageAllocator::AllocationHint().WithAddress(
+                                reinterpret_cast<void*>(hint)),
+                            params.base_alignment, params.permissions);
+  // The virtual memory reservation fails only due to OOM.
+  if (!reservation.IsReserved()) return false;
+
+  reservation_ = std::move(reservation);
+  base_ = reservation_.address();
+  CHECK_EQ(reservation_.size(), params.reservation_size);
   CHECK_NE(base_, kNullAddress);
   CHECK(IsAligned(base_, params.base_alignment));
 

--- a/src/utils/allocation.h
+++ b/src/utils/allocation.h
@@ -207,6 +207,17 @@ class VirtualMemory final {
       PageAllocator::AllocationHint hint = {}, size_t alignment = 1,
       PageAllocator::Permission permissions = PageAllocator::kNoAccess);
 
+  // Reserves virtual memory containing an area of the given size that is
+  // aligned per |alignment| rounded up to the |page_allocator|'s allocate page
+  // size. The |size| must be aligned with |page_allocator|'s commit page size.
+  // This may not be at the position returned by address().
+  // It uses handle as underlying file for the virtual memory.
+  V8_EXPORT_PRIVATE VirtualMemory(
+      PlatformSharedMemoryHandle handle, bool is_private,
+      v8::PageAllocator* page_allocator, size_t size,
+      PageAllocator::AllocationHint hint = {}, size_t alignment = 1,
+      PageAllocator::Permission permissions = PageAllocator::kNoAccess);
+
   // Construct a virtual memory by assigning it some already mapped address
   // and size.
   VirtualMemory(v8::PageAllocator* page_allocator, Address address, size_t size)
@@ -408,6 +419,10 @@ class VirtualMemoryCage {
   bool InitReservation(
       const ReservationParams& params,
       base::AddressRegion existing_reservation = base::AddressRegion());
+
+  bool InitReservation(const ReservationParams& params,
+                       PlatformSharedMemoryHandle underlying_memory_file,
+                       bool is_private = false);
 
   void Free();
 


### PR DESCRIPTION
We plan to share the code and trusted cages as well, so we apply the same mechanism used for sandbox cloning: allocate the original cage by creating an MAP_SHARED mapping of a memfd-created file, then create a copy-on-write (COW) clone by opening an MAP_PRIVATE mapping of the same file.