### PR TITLE
Part 3: Introduce heap cloning

### DIFF
--- a/src/common/code-memory-access.cc
+++ b/src/common/code-memory-access.cc
@@ -287,6 +287,18 @@ ThreadIsolation::JitPage::~JitPage() {
   // TODO(sroettger): check that the page is not in use (scan shadow stacks).
 }
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+void ThreadIsolation::JitPage::CloneAllocationsFrom(
+    JitPage* original, const VirtualMemoryCage* original_code_cage,
+    const VirtualMemoryCage* cloned_code_cage) {
+  for (const auto& [original_alloc_start, alloc] : original->allocations_) {
+    Address cloned_alloc_start =
+        original_code_cage->Rebase(original_alloc_start, cloned_code_cage);
+    allocations_.emplace(cloned_alloc_start, alloc);
+  }
+}
+#endif
+
 size_t ThreadIsolation::JitPageReference::Size() const {
   return jit_page_->size_;
 }
@@ -538,6 +550,21 @@ void ThreadIsolation::UnregisterJitAllocationForTesting(Address addr,
                                                         size_t size) {
   LookupJitPage(addr, size).UnregisterAllocation(addr);
 }
+
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+// static
+void ThreadIsolation::CloneJitAllocationsForPage(
+    Address original_page_address, const VirtualMemoryCage* original_code_cage,
+    Address cloned_page_address, const VirtualMemoryCage* cloned_code_cage,
+    size_t page_size) {
+  CFIMetadataWriteScope write_scope("Clone jit allocations for page");
+
+  auto original_jit_page = LookupJitPage(original_page_address, page_size);
+  auto cloned_jit_page = LookupJitPage(cloned_page_address, page_size);
+  cloned_jit_page.JitPage()->CloneAllocationsFrom(
+      original_jit_page.JitPage(), original_code_cage, cloned_code_cage);
+}
+#endif
 
 // static
 void ThreadIsolation::UnregisterWasmAllocation(Address addr, size_t size) {

--- a/src/common/code-memory-access.h
+++ b/src/common/code-memory-access.h
@@ -16,6 +16,10 @@
 #include "src/base/platform/mutex.h"
 #include "src/common/globals.h"
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+#include "src/utils/allocation.h"
+#endif
+
 namespace v8 {
 namespace internal {
 
@@ -216,6 +220,13 @@ class V8_EXPORT ThreadIsolation {
   static void CheckTrackedMemoryEmpty();
 #endif
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  static void CloneJitAllocationsForPage(
+      Address original_page_address,
+      const VirtualMemoryCage* original_code_cage, Address cloned_page_address,
+      const VirtualMemoryCage* cloned_code_cage, size_t page_size);
+#endif
+
   // A std::allocator implementation that wraps the ThreadIsolated allocator.
   // This is needed to create STL containers backed by ThreadIsolated memory.
   template <class T>
@@ -303,6 +314,12 @@ class V8_EXPORT ThreadIsolation {
    public:
     explicit JitPage(size_t size) : size_(size) {}
     ~JitPage();
+
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+    void CloneAllocationsFrom(JitPage* original,
+                              const VirtualMemoryCage* original_code_cage,
+                              const VirtualMemoryCage* cloned_code_cage);
+#endif
 
    private:
     base::Mutex mutex_;

--- a/src/heap/allocation-stats.h
+++ b/src/heap/allocation-stats.h
@@ -35,6 +35,26 @@ class AllocationStats {
     return *this;
   }
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  void CloneAndRebindFrom(const AllocationStats& other,
+                          IsolateGroup::MemoryChunkMetadataTableEntry* mpt) {
+    *this = other;
+#ifdef DEBUG
+    std::unordered_map<const MemoryChunkMetadata*, size_t,
+                       base::hash<const MemoryChunkMetadata*>>
+        allocated_on_page_new;
+    for (auto [memory_chunk_metadata, count] : allocated_on_page_) {
+      auto idx = memory_chunk_metadata->Chunk()->MetadataIndex();
+      if (mpt[idx].metadata()) {
+        DCHECK(mpt[idx].metadata());
+        allocated_on_page_new[mpt[idx].metadata()] = count;
+      }
+    }
+    allocated_on_page_ = std::move(allocated_on_page_new);
+#endif
+  }
+#endif
+
   // Zero out all the allocation statistics (i.e., no capacity).
   void Clear() {
     capacity_ = 0;

--- a/src/heap/base-space.h
+++ b/src/heap/base-space.h
@@ -51,6 +51,14 @@ class V8_EXPORT_PRIVATE BaseSpace : public Malloced {
  protected:
   BaseSpace(Heap* heap, AllocationSpace id) : heap_(heap), id_(id) {}
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  BaseSpace(Heap* heap, AllocationSpace id, BaseSpace* original)
+      : heap_(heap), id_(id) {
+    committed_.store(original->committed_.load());
+    max_committed_ = original->max_committed_;
+  }
+#endif
+
   virtual ~BaseSpace() = default;
 
   void AccountCommitted(size_t bytes) {

--- a/src/heap/free-list.cc
+++ b/src/heap/free-list.cc
@@ -95,7 +95,12 @@ void FreeListCategory::Free(const Heap* heap,
   Tagged<FreeSpace> free_space =
       Cast<FreeSpace>(HeapObject::FromAddress(writable_free_space.Address()));
   DCHECK_EQ(free_space->Size(), writable_free_space.Size());
-  free_space->SetNext(heap, writable_free_space, top());
+  if (PageMetadata::FromAddress(writable_free_space.Address())->heap() &&
+      !PageMetadata::FromAddress(writable_free_space.Address())
+           ->heap()
+           ->is_clone_heap_construction()) {
+    free_space->SetNext(heap, writable_free_space, top());
+  }
   set_top(free_space);
   size_t size_in_bytes = writable_free_space.Size();
   available_ += size_in_bytes;

--- a/src/heap/heap-allocator.cc
+++ b/src/heap/heap-allocator.cc
@@ -78,6 +78,172 @@ void HeapAllocator::Setup() {
   }
 }
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+void HeapAllocator::SetupClone(HeapAllocator* original) {
+  for (int i = FIRST_SPACE; i <= LAST_SPACE; ++i) {
+    spaces_[i] = heap_->space(i);
+  }
+
+  {
+    const auto* original_pointer_cage =
+        original->heap_->isolate()->isolate_group()->GetPtrComprCage();
+    const auto* cloned_pointer_cage =
+        heap_->isolate()->isolate_group()->GetPtrComprCage();
+    auto rebase = [original_pointer_cage,
+                   cloned_pointer_cage](const Address address) {
+      if (address == kNullAddress) {
+        return address;
+      }
+      return original_pointer_cage->Rebase(address, cloned_pointer_cage);
+    };
+
+    if ((heap_->new_space() || v8_flags.sticky_mark_bits) &&
+        local_heap_->is_main_thread()) {
+      MainAllocator* original_new_space_allocator =
+          original->new_space_allocator();
+      LinearAllocationArea* const new_allocation_info =
+          &heap_->isolate()->isolate_data()->new_allocation_info();
+      new_allocation_info->FullReset(
+          rebase(original_new_space_allocator->allocation_info().start()),
+          rebase(original_new_space_allocator->allocation_info().top()),
+          rebase(original_new_space_allocator->allocation_info().limit()));
+
+      DCHECK_EQ(new_allocation_info->top(),
+                rebase(original_new_space_allocator->allocation_info().top()));
+      DCHECK_EQ(
+          new_allocation_info->limit(),
+          rebase(original_new_space_allocator->allocation_info().limit()));
+
+      new_space_allocator_.emplace(
+          local_heap_,
+          v8_flags.sticky_mark_bits
+              ? static_cast<SpaceWithLinearArea*>(heap_->sticky_space())
+              : static_cast<SpaceWithLinearArea*>(heap_->new_space()),
+          MainAllocator::IsNewGeneration::kYes, original_new_space_allocator,
+          original_pointer_cage, cloned_pointer_cage, new_allocation_info);
+    }
+
+    if (local_heap_->is_main_thread()) {
+      Address* last_young_allocation_pointer = reinterpret_cast<Address*>(
+          heap_->isolate()->isolate_data()->last_young_allocation_address());
+      Address* original_last_young_allocation_pointer =
+          reinterpret_cast<Address*>(original->heap_->isolate()
+                                         ->isolate_data()
+                                         ->last_young_allocation_address());
+      if (original_last_young_allocation_pointer) {
+        *last_young_allocation_pointer =
+            rebase(*original_last_young_allocation_pointer);
+      }
+      last_young_allocation_pointer_ = last_young_allocation_pointer;
+    } else {
+      last_young_allocation_.emplace(kNullAddress);
+      last_young_allocation_pointer_ = &last_young_allocation_.value();
+    }
+
+    MainAllocator* original_old_space_allocator =
+        original->old_space_allocator();
+    LinearAllocationArea* const old_allocation_info =
+        local_heap_->is_main_thread()
+            ? &heap_->isolate()->isolate_data()->old_allocation_info()
+            : nullptr;
+    if (old_allocation_info) {
+      old_allocation_info->FullReset(
+          rebase(original_old_space_allocator->allocation_info().start()),
+          rebase(original_old_space_allocator->allocation_info().top()),
+          rebase(original_old_space_allocator->allocation_info().limit()));
+      DCHECK_EQ(old_allocation_info->top(),
+                rebase(original_old_space_allocator->allocation_info().top()));
+      DCHECK_EQ(
+          old_allocation_info->limit(),
+          rebase(original_old_space_allocator->allocation_info().limit()));
+    }
+
+    old_space_allocator_.emplace(
+        local_heap_, heap_->old_space(), MainAllocator::IsNewGeneration::kNo,
+        original_old_space_allocator, original_pointer_cage,
+        cloned_pointer_cage, old_allocation_info);
+  }
+
+  {
+    const auto* original_trust_cage =
+        original->heap_->isolate()->isolate_group()->GetTrustedPtrComprCage();
+    const auto* cloned_trust_cage =
+        heap_->isolate()->isolate_group()->GetTrustedPtrComprCage();
+    MainAllocator* original_trusted_space_allocator =
+        original->trusted_space_allocator();
+    trusted_space_allocator_.emplace(local_heap_, heap_->trusted_space(),
+                                     MainAllocator::IsNewGeneration::kNo,
+                                     original_trusted_space_allocator,
+                                     original_trust_cage, cloned_trust_cage);
+
+    auto rebase_trusted = [original_trust_cage,
+                           cloned_trust_cage](const Address address) {
+      if (address == kNullAddress) {
+        return address;
+      }
+      return original_trust_cage->Rebase(address, cloned_trust_cage);
+    };
+    trusted_space_allocator_->allocation_info().FullReset(
+        rebase_trusted(
+            original_trusted_space_allocator->allocation_info().start()),
+        rebase_trusted(
+            original_trusted_space_allocator->allocation_info().top()),
+        rebase_trusted(
+            original_trusted_space_allocator->allocation_info().limit()));
+    DCHECK_EQ(trusted_space_allocator()->top(),
+              rebase_trusted(
+                  original_trusted_space_allocator->allocation_info().top()));
+    DCHECK_EQ(trusted_space_allocator()->limit(),
+              rebase_trusted(
+                  original_trusted_space_allocator->allocation_info().limit()));
+  }
+
+  {
+    const auto* original_code_cage =
+        original->heap_->isolate()->isolate_group()->GetCodeRange();
+    const auto* cloned_code_cage =
+        heap_->isolate()->isolate_group()->GetCodeRange();
+    MainAllocator* original_code_space_allocator =
+        original->code_space_allocator();
+    code_space_allocator_.emplace(
+        local_heap_, heap_->code_space(), MainAllocator::IsNewGeneration::kNo,
+        original_code_space_allocator, original_code_cage, cloned_code_cage);
+    auto rebase_code = [original_code_cage,
+                        cloned_code_cage](const Address address) {
+      if (address == kNullAddress) {
+        return address;
+      }
+      return original_code_cage->Rebase(address, cloned_code_cage);
+    };
+
+    code_space_allocator_->allocation_info().FullReset(
+        rebase_code(original_code_space_allocator->allocation_info().start()),
+        rebase_code(original_code_space_allocator->allocation_info().top()),
+        rebase_code(original_code_space_allocator->allocation_info().limit()));
+
+    DCHECK_EQ(
+        code_space_allocator()->top(),
+        rebase_code(original_code_space_allocator->allocation_info().top()));
+    DCHECK_EQ(
+        code_space_allocator()->limit(),
+        rebase_code(original_code_space_allocator->allocation_info().limit()));
+  }
+
+  if (heap_->isolate()->has_shared_space()) {
+    // TODO(dbezhetskov): handle these allocators too.
+    shared_space_allocator_.emplace(local_heap_,
+                                    heap_->shared_allocation_space(),
+                                    MainAllocator::IsNewGeneration::kNo);
+    shared_lo_space_ = heap_->shared_lo_allocation_space();
+
+    shared_trusted_space_allocator_.emplace(
+        local_heap_, heap_->shared_trusted_allocation_space(),
+        MainAllocator::IsNewGeneration::kNo);
+    shared_trusted_lo_space_ = heap_->shared_trusted_lo_allocation_space();
+  }
+}
+#endif
+
 void HeapAllocator::SetReadOnlySpace(ReadOnlySpace* read_only_space) {
   read_only_space_ = read_only_space;
 }

--- a/src/heap/heap-allocator.h
+++ b/src/heap/heap-allocator.h
@@ -44,6 +44,10 @@ class V8_EXPORT_PRIVATE HeapAllocator final {
 
   void SetReadOnlySpace(ReadOnlySpace*);
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  void SetupClone(HeapAllocator* original);
+#endif
+
   // Supports all `AllocationType` types.
   //
   // Returns a failed result on an unsuccessful allocation attempt.

--- a/src/heap/heap.cc
+++ b/src/heap/heap.cc
@@ -6352,6 +6352,107 @@ void Heap::SetUpSpaces() {
   }
 }
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+void Heap::SetUpSpacesClone(Heap* original) {
+  // Ensure SetUpFromReadOnlySpace has been ran.
+  DCHECK_NOT_NULL(read_only_space_);
+
+  if (v8_flags.sticky_mark_bits) {
+    DCHECK(false);  // NYI.
+  } else {
+    space_[OLD_SPACE] = std::make_unique<OldSpace>(this, original->old_space());
+    old_space_ = static_cast<OldSpace*>(space_[OLD_SPACE].get());
+  }
+
+  if (!v8_flags.single_generation) {
+    if (!v8_flags.sticky_mark_bits) {
+      if (v8_flags.minor_ms) {
+        DCHECK(false);  // NYI.
+      } else {
+        space_[NEW_SPACE] = std::make_unique<SemiSpaceNewSpace>(
+            this, original->semi_space_new_space());
+      }
+      new_space_ = static_cast<NewSpace*>(space_[NEW_SPACE].get());
+    }
+
+    space_[NEW_LO_SPACE] = std::make_unique<NewLargeObjectSpace>(
+        this, original->new_lo_space(), NewSpaceCapacity());
+    new_lo_space_ =
+        static_cast<NewLargeObjectSpace*>(space_[NEW_LO_SPACE].get());
+  }
+
+  space_[CODE_SPACE] =
+      std::make_unique<CodeSpace>(this, original->code_space());
+  code_space_ = static_cast<CodeSpace*>(space_[CODE_SPACE].get());
+
+  space_[LO_SPACE] =
+      std::make_unique<OldLargeObjectSpace>(this, original->lo_space());
+  lo_space_ = static_cast<OldLargeObjectSpace*>(space_[LO_SPACE].get());
+
+  space_[CODE_LO_SPACE] =
+      std::make_unique<CodeLargeObjectSpace>(this, original->code_lo_space());
+  code_lo_space_ =
+      static_cast<CodeLargeObjectSpace*>(space_[CODE_LO_SPACE].get());
+
+  space_[TRUSTED_SPACE] =
+      std::make_unique<TrustedSpace>(this, original->trusted_space());
+  trusted_space_ = static_cast<TrustedSpace*>(space_[TRUSTED_SPACE].get());
+
+  space_[TRUSTED_LO_SPACE] = std::make_unique<TrustedLargeObjectSpace>(
+      this, original->trusted_lo_space());
+  trusted_lo_space_ =
+      static_cast<TrustedLargeObjectSpace*>(space_[TRUSTED_LO_SPACE].get());
+
+  if (isolate()->is_shared_space_isolate()) {
+    DCHECK(!v8_flags.sticky_mark_bits);
+    DCHECK(false);  // NYI.
+  }
+
+  if (isolate()->has_shared_space()) {
+    DCHECK(false);  // NYI.
+  }
+
+  main_thread_local_heap()->SetUpMainThreadClone(
+      original->main_thread_local_heap());
+
+  base::TimeTicks startup_time = base::TimeTicks::Now();
+
+  tracer_.reset(new GCTracer(this, startup_time));
+  array_buffer_sweeper_.reset(new ArrayBufferSweeper(this));
+  memory_measurement_.reset(new MemoryMeasurement(isolate()));
+  if (v8_flags.memory_reducer) memory_reducer_.reset(new MemoryReducer(this));
+  if (V8_UNLIKELY(TracingFlags::is_gc_stats_enabled())) {
+    live_object_stats_.reset(new ObjectStats(this));
+    dead_object_stats_.reset(new ObjectStats(this));
+  }
+  if (Heap::AllocationTrackerForDebugging::IsNeeded()) {
+    allocation_tracker_for_debugging_ =
+        std::make_unique<Heap::AllocationTrackerForDebugging>(this);
+  }
+
+  LOG(isolate_, IntPtrTEvent("heap-capacity", Capacity()));
+  LOG(isolate_, IntPtrTEvent("heap-available", Available()));
+
+  SetGetExternallyAllocatedMemoryInBytesCallback(ReturnNull);
+
+  if (v8_flags.stress_marking > 0) {
+    stress_marking_percentage_ = NextStressMarkingLimit();
+  }
+  if (IsStressingScavenge()) {
+    stress_scavenge_observer_ = new StressScavengeObserver(this);
+    allocator()->new_space_allocator()->AddAllocationObserver(
+        stress_scavenge_observer_);
+  }
+
+  if (v8_flags.memory_balancer) {
+    mb_.reset(new MemoryBalancer(this, startup_time));
+  }
+
+  // It is not longer a clone it is a fully instantiated heap.
+  is_clone_heap_construction_ = false;
+}
+#endif
+
 void Heap::InitializeHashSeed() {
   DCHECK(!deserialization_complete_);
   uint64_t new_hash_seed;

--- a/src/heap/heap.cc
+++ b/src/heap/heap.cc
@@ -2822,6 +2822,36 @@ void Heap::Scavenge() {
   SetGCState(NOT_IN_GC);
 }
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+void Heap::ExternalStringTable::CopyDataFrom(ExternalStringTable* original,
+                                             Heap* original_heap) {
+  base::MutexGuard original_guard(original->mutex_);
+  base::MutexGuard current_guard(mutex_);
+
+  VirtualMemoryCage* original_cage =
+      original_heap->isolate()->isolate_group()->GetPtrComprCage();
+  VirtualMemoryCage* current_cage =
+      heap_->isolate()->isolate_group()->GetPtrComprCage();
+  auto rebase = [original_cage, current_cage](Address address) {
+    return original_cage->Rebase(address, current_cage);
+  };
+
+  for (TaggedBase& str : original->young_strings_) {
+    Address str_address = str.ptr();
+    DCHECK(original_cage->region().contains(str_address));
+    young_strings_.push_back(
+        HeapObject::FromAddress(rebase(str_address) - kHeapObjectTag));
+  }
+
+  for (TaggedBase& str : original->old_strings_) {
+    Address str_address = str.ptr();
+    DCHECK(original_cage->region().contains(str_address));
+    old_strings_.push_back(
+        HeapObject::FromAddress(rebase(str_address) - kHeapObjectTag));
+  }
+}
+#endif
+
 bool Heap::ExternalStringTable::Contains(Tagged<String> string) {
   for (size_t i = 0; i < young_strings_.size(); ++i) {
     if (young_strings_[i] == string) return true;
@@ -6576,6 +6606,7 @@ void Heap::SetUpClone(LocalHeap* main_thread_local_heap, Heap* target) {
   backing_store_bytes_.store(target->backing_store_bytes_.load());
   ms_count_ = target->ms_count_;
   gc_count_ = target->gc_count_;
+  external_string_table_.CopyDataFrom(&target->external_string_table_, target);
 
   promoted_objects_size_ = target->promoted_objects_size_;
   promotion_ratio_ = target->promotion_ratio_;

--- a/src/heap/heap.cc
+++ b/src/heap/heap.cc
@@ -6451,6 +6451,144 @@ void Heap::SetUpSpacesClone(Heap* original) {
   // It is not longer a clone it is a fully instantiated heap.
   is_clone_heap_construction_ = false;
 }
+
+void Heap::SetUpClone(LocalHeap* main_thread_local_heap, Heap* target) {
+  DCHECK_NULL(main_thread_local_heap_);
+  DCHECK_NULL(heap_allocator_);
+  main_thread_local_heap_ = main_thread_local_heap;
+  heap_allocator_ = &main_thread_local_heap->heap_allocator_;
+  DCHECK_NOT_NULL(heap_allocator_);
+  is_clone_heap_construction_ = true;
+
+  // Set the stack start for the main thread that sets up the heap.
+  SetStackStart();
+
+#ifdef V8_ENABLE_ALLOCATION_TIMEOUT
+  heap_allocator_->UpdateAllocationTimeout();
+#endif  // V8_ENABLE_ALLOCATION_TIMEOUT
+
+  // Initialize heap spaces and initial maps and objects.
+  //
+  // If the heap is not yet configured (e.g. through the API), configure it.
+  // Configuration is based on the flags new-space-size (really the semispace
+  // size) and old-space-size if set or the initial values of semispace_size_
+  // and old_generation_size_ otherwise.
+  if (!configured_) ConfigureHeapDefault();
+
+  v8::PageAllocator* code_page_allocator;
+  if (isolate_->RequiresCodeRange() || code_range_size_ != 0) {
+    const size_t requested_size =
+        code_range_size_ == 0 ? kMaximalCodeRangeSize : code_range_size_;
+    // When a target requires the code range feature, we put all code objects in
+    // a contiguous range of virtual address space, so that they can call each
+    // other with near calls.
+#ifdef V8_COMPRESS_POINTERS
+    // When pointer compression is enabled, isolates in the same group share the
+    // same CodeRange, owned by the IsolateGroup.
+    code_range_ = isolate_->isolate_group()->EnsureCodeRange(
+        requested_size, target->isolate()->isolate_group()->GetCodeRange());
+#else
+    // Otherwise, each isolate has its own CodeRange, owned by the heap.
+    code_range_ = std::make_unique<CodeRange>();
+    if (!code_range_->InitReservation(isolate_->page_allocator(),
+                                      requested_size, false)) {
+      V8::FatalProcessOutOfMemory(
+          isolate_, "Failed to reserve virtual memory for CodeRange");
+    }
+#endif  // V8_COMPRESS_POINTERS_IN_SHARED_CAGE
+
+    LOG(isolate_,
+        NewEvent("CodeRange",
+                 reinterpret_cast<void*>(code_range_->reservation()->address()),
+                 code_range_size_));
+
+    isolate_->AddCodeRange(code_range_->reservation()->region().begin(),
+                           code_range_->reservation()->region().size());
+    code_page_allocator = code_range_->page_allocator();
+  } else {
+    code_page_allocator = isolate_->page_allocator();
+  }
+
+  v8::PageAllocator* trusted_page_allocator;
+#ifdef V8_ENABLE_SANDBOX
+  trusted_page_allocator =
+      isolate_->isolate_group()->GetTrustedPtrComprCage()->page_allocator();
+#else
+  trusted_page_allocator = isolate_->page_allocator();
+#endif
+
+  task_runner_ = V8::GetCurrentPlatform()->GetForegroundTaskRunner(
+      reinterpret_cast<v8::Isolate*>(isolate()));
+
+  collection_barrier_.reset(new CollectionBarrier(this, this->task_runner_));
+
+  // Set up memory allocator.
+  memory_allocator_.reset(new MemoryAllocator(
+      isolate_, code_page_allocator, trusted_page_allocator,
+      isolate_->isolate_group()->memory_pool(), MaxReserved()));
+
+  sweeper_.reset(new Sweeper(this));
+
+  mark_compact_collector_.reset(new MarkCompactCollector(this));
+
+  scavenger_collector_.reset(new ScavengerCollector(this));
+  minor_mark_sweep_collector_.reset(new MinorMarkSweepCollector(this));
+  ephemeron_remembered_set_.reset(new EphemeronRememberedSet());
+
+  incremental_marking_.reset(
+      new IncrementalMarking(this, mark_compact_collector_->weak_objects()));
+
+  if (v8_flags.concurrent_marking || v8_flags.parallel_marking) {
+    concurrent_marking_.reset(
+        new ConcurrentMarking(this, mark_compact_collector_->weak_objects()));
+  } else {
+    concurrent_marking_.reset(new ConcurrentMarking(this, nullptr));
+  }
+
+  // Set up layout tracing callback.
+  if (V8_UNLIKELY(v8_flags.trace_gc_heap_layout)) {
+    v8::GCType gc_type = kGCTypeMarkSweepCompact;
+    if (V8_UNLIKELY(!v8_flags.trace_gc_heap_layout_ignore_minor_gc)) {
+      gc_type = static_cast<v8::GCType>(gc_type | kGCTypeScavenge |
+                                        kGCTypeMinorMarkSweep);
+    }
+    AddGCPrologueCallback(HeapLayoutTracer::GCProloguePrintHeapLayout, gc_type,
+                          nullptr);
+    AddGCEpilogueCallback(HeapLayoutTracer::GCEpiloguePrintHeapLayout, gc_type,
+                          nullptr);
+  }
+
+  old_generation_allocation_limit_.store(
+      target->old_generation_allocation_limit_.load());
+  global_allocation_limit_.store(target->global_allocation_limit_.load());
+  contexts_disposed_ = target->contexts_disposed_;
+  maximum_committed_ = target->maximum_committed_;
+
+  VirtualMemoryCage* original_cage =
+      target->isolate()->isolate_group()->GetPtrComprCage();
+  VirtualMemoryCage* cloned_cage =
+      isolate()->isolate_group()->GetPtrComprCage();
+  Address original_native_ctx = target->native_contexts_list_.load();
+  Address cloned_native_ctx =
+      original_cage->Rebase(original_native_ctx, cloned_cage);
+  native_contexts_list_.store(cloned_native_ctx);
+
+  backing_store_bytes_.store(target->backing_store_bytes_.load());
+  ms_count_ = target->ms_count_;
+  gc_count_ = target->gc_count_;
+
+  promoted_objects_size_ = target->promoted_objects_size_;
+  promotion_ratio_ = target->promotion_ratio_;
+  promotion_rate_ = target->promotion_rate_;
+  new_space_surviving_object_size_ = target->new_space_surviving_object_size_;
+  previous_new_space_surviving_object_size_ =
+      target->previous_new_space_surviving_object_size_;
+  new_space_surviving_rate_ = target->new_space_surviving_rate_;
+  nodes_died_in_new_space_ = target->nodes_died_in_new_space_;
+  nodes_copied_in_new_space_ = target->nodes_copied_in_new_space_;
+  nodes_promoted_ = target->nodes_promoted_;
+  last_gc_time_ = target->last_gc_time_;
+}
 #endif
 
 void Heap::InitializeHashSeed() {

--- a/src/heap/heap.h
+++ b/src/heap/heap.h
@@ -1753,6 +1753,10 @@ class Heap final {
     ExternalStringTable(const ExternalStringTable&) = delete;
     ExternalStringTable& operator=(const ExternalStringTable&) = delete;
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+    void CopyDataFrom(ExternalStringTable* original, Heap* original_heap);
+#endif
+
     // Registers an external string.
     inline void AddString(Tagged<String> string);
     bool Contains(Tagged<String> string);

--- a/src/heap/heap.h
+++ b/src/heap/heap.h
@@ -731,6 +731,12 @@ class Heap final {
   // Sets up the heap memory without creating any objects.
   void SetUpSpaces();
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  // Sets up the heap memory without creating any objects
+  // as an clone of the original heap.
+  void SetUpSpacesClone(Heap* original);
+#endif
+
   // Prepares the heap, setting up for deserialization.
   void InitializeMainThreadLocalHeap(LocalHeap* main_thread_local_heap);
 
@@ -1720,6 +1726,13 @@ class Heap final {
 
   bool IsNewSpaceAllowedToGrowAboveTargetCapacity() const;
 
+  bool is_clone_heap_construction() const {
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+    return is_clone_heap_construction_;
+#endif
+    return false;
+  }
+
  private:
   class AllocationTrackerForDebugging;
 
@@ -2541,6 +2554,12 @@ class Heap final {
   // In such cases we may want to update the limits again once loading is
   // actually finished.
   bool update_allocation_limits_after_loading_ = false;
+
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  // True if we are in a process of constructing a cloned heap.
+  // It is needed to not to spoil memory cloned from the original heap.
+  bool is_clone_heap_construction_ = false;
+#endif
 
   // On-stack address used for selective consevative stack scanning. No value
   // means that selective conservative stack scanning is not enabled.

--- a/src/heap/heap.h
+++ b/src/heap/heap.h
@@ -732,6 +732,9 @@ class Heap final {
   void SetUpSpaces();
 
 #ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  // Prepares the heap, setting up for cloning.
+  void SetUpClone(LocalHeap* main_thread_local_heap, Heap* target);
+
   // Sets up the heap memory without creating any objects
   // as an clone of the original heap.
   void SetUpSpacesClone(Heap* original);

--- a/src/heap/large-spaces.cc
+++ b/src/heap/large-spaces.cc
@@ -57,6 +57,63 @@ LargeObjectSpace::LargeObjectSpace(Heap* heap, AllocationSpace id)
       objects_size_(0),
       pending_object_(0) {}
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+LargeObjectSpace::LargeObjectSpace(Heap* heap, LargeObjectSpace* original,
+                                   AllocationSpace id)
+    : Space(heap, original, id, nullptr),
+      size_(0),
+      page_count_(0),
+      objects_size_(0),
+      pending_object_(0) {
+  base::MutexGuard expansion_guard(heap->heap_expansion_mutex());
+  const VirtualMemoryCage* original_cage = original->GetCage();
+  const VirtualMemoryCage* cloned_cage = GetCage();
+  for (LargePageMetadata* original_page : *original) {
+#ifdef DEBUG
+    Address new_area_start =
+        original_cage->Rebase(original_page->area_start(), cloned_cage);
+    Address new_area_end =
+        original_cage->Rebase(original_page->area_end(), cloned_cage);
+#endif
+    Address page_base =
+        original_cage->Rebase(original_page->ChunkAddress(), cloned_cage);
+    DCHECK(original_page->Chunk()->IsLargePage());
+
+    LargePageMetadata* cloned_page =
+        heap->memory_allocator()->AllocateLargePageAt(
+            this, page_base, original_page->area_size(),
+            original_page->is_executable() ? Executability::EXECUTABLE
+                                           : Executability::NOT_EXECUTABLE);
+    cloned_page->CopyStateFrom(original_page, original_cage, cloned_cage);
+
+    // Check that a newly allocated page corresponds to
+    // the same offsets.
+    DCHECK_EQ(cloned_page->area_size(), original_page->area_size());
+    DCHECK_EQ(cloned_page->area_start(), new_area_start);
+    DCHECK_EQ(cloned_page->area_end(), new_area_end);
+    DCHECK_EQ(cloned_page->size(), original_page->size());
+
+    {
+      base::RecursiveMutexGuard guard(&allocation_mutex_);
+      AddPage(cloned_page, cloned_page->area_size());
+    }
+    DCHECK_EQ(cloned_page->allocated_bytes(), original_page->allocated_bytes());
+    DCHECK_EQ(cloned_page->wasted_memory(), original_page->wasted_memory());
+  }
+
+  DCHECK_EQ(size_, original->size_);
+  DCHECK_EQ(page_count_, original->page_count_);
+  DCHECK_EQ(objects_size_, original->objects_size_);
+
+  base::MutexGuard guard(pending_allocation_mutex_);
+  const Address pending_object_addr = original->pending_object_.load();
+  if (pending_object_addr != kNullAddress) {
+    pending_object_.store(
+        original_cage->Rebase(pending_object_addr, cloned_cage));
+  }
+}
+#endif
+
 size_t LargeObjectSpace::Available() const {
   // We return zero here since we cannot take advantage of already allocated
   // large object memory.
@@ -486,6 +543,30 @@ SharedTrustedLargeObjectSpace::SharedTrustedLargeObjectSpace(Heap* heap)
 
 TrustedLargeObjectSpace::TrustedLargeObjectSpace(Heap* heap)
     : OldLargeObjectSpace(heap, TRUSTED_LO_SPACE) {}
+
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+OldLargeObjectSpace::OldLargeObjectSpace(Heap* heap,
+                                         OldLargeObjectSpace* original)
+    : LargeObjectSpace(heap, original, LO_SPACE) {}
+
+OldLargeObjectSpace::OldLargeObjectSpace(Heap* heap,
+                                         OldLargeObjectSpace* original,
+                                         AllocationSpace id)
+    : LargeObjectSpace(heap, original, id) {}
+
+NewLargeObjectSpace::NewLargeObjectSpace(Heap* heap,
+                                         NewLargeObjectSpace* original,
+                                         size_t capacity)
+    : LargeObjectSpace(heap, original, NEW_LO_SPACE), capacity_(capacity) {}
+
+CodeLargeObjectSpace::CodeLargeObjectSpace(Heap* heap,
+                                           CodeLargeObjectSpace* original)
+    : OldLargeObjectSpace(heap, original, CODE_LO_SPACE) {}
+
+TrustedLargeObjectSpace::TrustedLargeObjectSpace(
+    Heap* heap, TrustedLargeObjectSpace* original)
+    : OldLargeObjectSpace(heap, original, TRUSTED_LO_SPACE) {}
+#endif
 
 }  // namespace internal
 }  // namespace v8

--- a/src/heap/large-spaces.h
+++ b/src/heap/large-spaces.h
@@ -112,6 +112,10 @@ class V8_EXPORT_PRIVATE LargeObjectSpace : public Space {
  protected:
   LargeObjectSpace(Heap* heap, AllocationSpace id);
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  LargeObjectSpace(Heap* heap, LargeObjectSpace* original, AllocationSpace id);
+#endif
+
   void AdvanceAndInvokeAllocationObservers(Address soon_object, size_t size);
 
   LargePageMetadata* AllocateLargePage(int object_size,
@@ -146,6 +150,11 @@ class OldLargeObjectSpace : public LargeObjectSpace {
  public:
   V8_EXPORT_PRIVATE explicit OldLargeObjectSpace(Heap* heap);
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  V8_EXPORT_PRIVATE OldLargeObjectSpace(Heap* heap,
+                                        OldLargeObjectSpace* original);
+#endif
+
   V8_EXPORT_PRIVATE V8_WARN_UNUSED_RESULT AllocationResult
   AllocateRaw(LocalHeap* local_heap, int object_size, AllocationHint hint);
 
@@ -153,6 +162,12 @@ class OldLargeObjectSpace : public LargeObjectSpace {
 
  protected:
   explicit OldLargeObjectSpace(Heap* heap, AllocationSpace id);
+
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  explicit OldLargeObjectSpace(Heap* heap, OldLargeObjectSpace* original,
+                               AllocationSpace id);
+#endif
+
   V8_WARN_UNUSED_RESULT AllocationResult AllocateRaw(LocalHeap* local_heap,
                                                      int object_size,
                                                      Executability executable,
@@ -168,6 +183,10 @@ class SharedLargeObjectSpace : public OldLargeObjectSpace {
 class TrustedLargeObjectSpace : public OldLargeObjectSpace {
  public:
   explicit TrustedLargeObjectSpace(Heap* heap);
+
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  TrustedLargeObjectSpace(Heap* heap, TrustedLargeObjectSpace* original);
+#endif
 };
 
 // Similar to the TrustedLargeObjectSpace, but for shared objects.
@@ -179,6 +198,11 @@ class SharedTrustedLargeObjectSpace : public OldLargeObjectSpace {
 class NewLargeObjectSpace : public LargeObjectSpace {
  public:
   NewLargeObjectSpace(Heap* heap, size_t capacity);
+
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  NewLargeObjectSpace(Heap* heap, NewLargeObjectSpace* original,
+                      size_t capacity);
+#endif
 
   V8_EXPORT_PRIVATE V8_WARN_UNUSED_RESULT AllocationResult
   AllocateRaw(LocalHeap* local_heap, int object_size, AllocationHint hint);
@@ -199,6 +223,10 @@ class NewLargeObjectSpace : public LargeObjectSpace {
 class CodeLargeObjectSpace : public OldLargeObjectSpace {
  public:
   explicit CodeLargeObjectSpace(Heap* heap);
+
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  CodeLargeObjectSpace(Heap* heap, CodeLargeObjectSpace* original);
+#endif
 
   V8_EXPORT_PRIVATE V8_WARN_UNUSED_RESULT AllocationResult
   AllocateRaw(LocalHeap* local_heap, int object_size, AllocationHint hint);

--- a/src/heap/linear-allocation-area.h
+++ b/src/heap/linear-allocation-area.h
@@ -10,6 +10,10 @@
 #include "include/v8-internal.h"
 #include "src/common/checks.h"
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+#include "src/utils/allocation.h"
+#endif
+
 namespace v8::internal {
 
 // A linear allocation area to allocate objects from.
@@ -30,6 +34,15 @@ class LinearAllocationArea final {
     limit_ = limit;
     Verify();
   }
+
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  void FullReset(Address start, Address top, Address limit) {
+    start_ = start;
+    top_ = top;
+    limit_ = limit;
+    Verify();
+  }
+#endif
 
   void ResetStart() { start_ = top_; }
 

--- a/src/heap/local-heap.cc
+++ b/src/heap/local-heap.cc
@@ -137,6 +137,16 @@ void LocalHeap::SetUpMainThread() {
   SetUpSharedMarking();
 }
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+void LocalHeap::SetUpMainThreadClone(LocalHeap* original) {
+  DCHECK(is_main_thread());
+  DCHECK(IsRunning());
+  heap_allocator_.SetupClone(&original->heap_allocator_);
+  SetUpMarkingBarrier();
+  SetUpSharedMarking();
+}
+#endif
+
 void LocalHeap::SetUpMarkingBarrier() {
   DCHECK_NULL(marking_barrier_);
   marking_barrier_ = std::make_unique<MarkingBarrier>(this);

--- a/src/heap/local-heap.h
+++ b/src/heap/local-heap.h
@@ -394,6 +394,10 @@ class V8_EXPORT_PRIVATE LocalHeap {
   // Set up this LocalHeap as main thread.
   void SetUpMainThread();
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  void SetUpMainThreadClone(LocalHeap* original);
+#endif
+
   void SetUpMarkingBarrier();
   void SetUpSharedMarking();
 

--- a/src/heap/main-allocator.cc
+++ b/src/heap/main-allocator.cc
@@ -55,6 +55,50 @@ MainAllocator::MainAllocator(LocalHeap* local_heap, SpaceWithLinearArea* space,
   }
 }
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+MainAllocator::MainAllocator(LocalHeap* local_heap, SpaceWithLinearArea* space,
+                             IsNewGeneration is_new_generation,
+                             MainAllocator* original,
+                             const VirtualMemoryCage* original_cage,
+                             const VirtualMemoryCage* cloned_cage,
+                             LinearAllocationArea* allocation_info)
+    : local_heap_(local_heap),
+      isolate_heap_(local_heap->heap()),
+      space_(space),
+      allocation_info_(allocation_info != nullptr ? allocation_info
+                                                  : &owned_allocation_info_),
+      allocator_policy_(space->CreateAllocatorPolicy(this)),
+      supports_extending_lab_(allocator_policy_->SupportsExtendingLAB()),
+      black_allocation_(ComputeBlackAllocation(is_new_generation)) {
+  CHECK_NOT_NULL(local_heap_);
+
+  auto rebase = [original_cage, cloned_cage](const Address address) {
+    if (address == kNullAddress) {
+      return address;
+    }
+    return original_cage->Rebase(address, cloned_cage);
+  };
+
+  if (local_heap_->is_main_thread()) {
+    allocation_counter_.emplace();
+    linear_area_original_data_.emplace();
+    auto [current_top, current_limit] =
+        original->linear_area_original_data_->GetTopAndLimit();
+    const Address new_top = rebase(current_top);
+    const Address new_limit = rebase(current_limit);
+    linear_area_original_data_->InitFromClone(new_top, new_limit);
+  }
+
+  DCHECK_EQ(supports_extending_lab_, original->supports_extending_lab_);
+  // TODO(dbezhetskov): check this.
+  if (original_cage->Contains(original->extended_limit_)) {
+    extended_limit_ = rebase(original->extended_limit_);
+  } else {
+    extended_limit_ = original->extended_limit_;
+  }
+}
+#endif
+
 MainAllocator::MainAllocator(Heap* heap, SpaceWithLinearArea* space, InGCTag)
     : local_heap_(nullptr),
       isolate_heap_(heap),

--- a/src/heap/main-allocator.h
+++ b/src/heap/main-allocator.h
@@ -140,6 +140,13 @@ class LinearAreaOriginalData {
 
   void SetTopAndLimit(Address top, Address limit);
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  void InitFromClone(Address new_top, Address new_limit_) {
+    original_top_.store(new_top);
+    original_limit_.store(new_limit_);
+  }
+#endif
+
  private:
   // The top and the limit at the time of setting the linear allocation area.
   // These values can be accessed by background tasks. Protected by mutex_.
@@ -164,6 +171,15 @@ class MainAllocator {
       LocalHeap* heap, SpaceWithLinearArea* space,
       IsNewGeneration is_new_generation,
       LinearAllocationArea* allocation_info = nullptr);
+
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  V8_EXPORT_PRIVATE MainAllocator(
+      LocalHeap* heap, SpaceWithLinearArea* space,
+      IsNewGeneration is_new_generation, MainAllocator* original,
+      const VirtualMemoryCage* original_cage,
+      const VirtualMemoryCage* cloned_cage,
+      LinearAllocationArea* allocation_info = nullptr);
+#endif
 
   // Use this constructor for GC LABs/allocations.
   V8_EXPORT_PRIVATE MainAllocator(Heap* heap, SpaceWithLinearArea* space,

--- a/src/heap/marking-progress-tracker.h
+++ b/src/heap/marking-progress-tracker.h
@@ -54,6 +54,13 @@ class MarkingProgressTracker final {
     }
   }
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  void CloneFrom(const MarkingProgressTracker& other) {
+    overall_chunks_ = other.overall_chunks_;
+    current_chunk_.store(other.current_chunk_.load());
+  }
+#endif
+
   size_t GetCurrentChunkForTesting() const {
     return current_chunk_.load(std::memory_order_relaxed);
   }

--- a/src/heap/marking.h
+++ b/src/heap/marking.h
@@ -7,6 +7,11 @@
 
 #include <cstdint>
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+#include <algorithm>
+#include <iterator>
+#endif
+
 #include "src/base/atomic-utils.h"
 #include "src/common/globals.h"
 #include "src/heap/marking-worklist.h"
@@ -159,7 +164,14 @@ class V8_EXPORT_PRIVATE MarkingBitmap final {
 
   MarkingBitmap() = default;
   MarkingBitmap(const MarkingBitmap&) = delete;
-  MarkingBitmap& operator=(const MarkingBitmap&) = delete;
+
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  MarkingBitmap& operator=(const MarkingBitmap& other) {
+    std::copy(std::begin(other.cells_), std::end(other.cells_),
+              std::begin(cells_));
+    return *this;
+  }
+#endif
 
   V8_INLINE CellType* cells() { return cells_; }
   V8_INLINE const CellType* cells() const { return cells_; }

--- a/src/heap/memory-allocator.cc
+++ b/src/heap/memory-allocator.cc
@@ -280,7 +280,8 @@ void MemoryAllocator::UnregisterSharedMemoryChunk(MemoryChunkMetadata* chunk) {
 void MemoryAllocator::UnregisterMemoryChunk(
     MemoryChunkMetadata* chunk_metadata) {
   MemoryChunk* chunk = chunk_metadata->Chunk();
-  DCHECK(!chunk_metadata->is_unregistered());
+  DCHECK_IMPLIES(!isolate_->heap()->is_clone_heap_construction(),
+                 !chunk_metadata->is_unregistered());
   VirtualMemory* reservation = chunk_metadata->reserved_memory();
   const size_t size =
       reservation->IsReserved() ? reservation->size() : chunk_metadata->size();
@@ -300,7 +301,8 @@ void MemoryAllocator::UnregisterMemoryChunk(
   }
   // For non-RO pages we want to set them as UNREGISTERED to allow actually
   // freeing them.
-  if (!chunk->InReadOnlySpace()) {
+  if (!isolate_->heap()->is_clone_heap_construction() &&
+      !chunk->InReadOnlySpace()) {
     // Cannot use MutablePageMetadata::cast() because that relies on having an
     // owner() which is unsed at this point.
     reinterpret_cast<MutablePageMetadata*>(chunk_metadata)
@@ -531,12 +533,30 @@ PageMetadata* MemoryAllocator::AllocatePageAt(Space* space,
       &trusted_flags);
   if (executable) {
     RwxMemoryWriteScope scope("Initialize a new MemoryChunk.");
-    new (chunk_info->chunk) MemoryChunk(trusted_flags, metadata);
+    if (isolate_->heap()->is_clone_heap_construction()) {
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+      MemoryChunk::UpdateMPT(reinterpret_cast<Address>(chunk_info->chunk),
+                             metadata);
+#endif
+    } else {
+      new (chunk_info->chunk) MemoryChunk(trusted_flags, metadata);
+    }
 #ifdef DEBUG
     RegisterExecutableMemoryChunk(metadata);
 #endif  // DEBUG
   } else {
-    new (chunk_info->chunk) MemoryChunk(trusted_flags, metadata);
+    if (isolate_->heap()->is_clone_heap_construction()) {
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+      // We don't need to construct memory chunk because we already have one
+      // in memory and it should be with the same data.
+      // There is way to avoid this change and just reset cloned sandbox after
+      // creation and reduce diff with upstream but it will be slower a bit.
+      MemoryChunk::UpdateMPT(reinterpret_cast<Address>(chunk_info->chunk),
+                             metadata);
+#endif
+    } else {
+      new (chunk_info->chunk) MemoryChunk(trusted_flags, metadata);
+    }
   }
 
   DCHECK(metadata->IsLivenessClear());
@@ -576,12 +596,27 @@ LargePageMetadata* MemoryAllocator::AllocateLargePageAt(
       &trusted_flags);
   if (executable) {
     RwxMemoryWriteScope scope("Initialize a new MemoryChunk.");
-    new (chunk_info->chunk) MemoryChunk(trusted_flags, metadata);
+    if (isolate_->heap()->is_clone_heap_construction()) {
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+      // See comment in AllocatePageAt.
+      MemoryChunk::UpdateMPT(reinterpret_cast<Address>(chunk_info->chunk),
+                             metadata);
+#endif
+    } else {
+      new (chunk_info->chunk) MemoryChunk(trusted_flags, metadata);
+    }
 #ifdef DEBUG
     RegisterExecutableMemoryChunk(metadata);
 #endif  // DEBUG
   } else {
-    new (chunk_info->chunk) MemoryChunk(trusted_flags, metadata);
+    if (isolate_->heap()->is_clone_heap_construction()) {
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+      MemoryChunk::UpdateMPT(reinterpret_cast<Address>(chunk_info->chunk),
+                             metadata);
+#endif
+    } else {
+      new (chunk_info->chunk) MemoryChunk(trusted_flags, metadata);
+    }
   }
 
   RecordMemoryChunkCreated(metadata);

--- a/src/heap/memory-allocator.cc
+++ b/src/heap/memory-allocator.cc
@@ -506,6 +506,89 @@ bool IsPagePoolSupportedForLargeSpace(LargeObjectSpace* space) {
 }
 }  // namespace
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+PageMetadata* MemoryAllocator::AllocatePageAt(Space* space,
+                                              Executability executable,
+                                              Address start) {
+  const size_t size =
+      MemoryChunkLayout::AllocatableMemoryInMemoryChunk(space->identity());
+  std::optional<MemoryChunkAllocationResult> chunk_info;
+
+  if (!chunk_info) {
+    chunk_info = AllocateUninitializedChunkAt(
+        space, size, executable, start, PageSize::kRegular, AllocationHint());
+  }
+  if (!chunk_info) return nullptr;
+
+  PageMetadata* metadata;
+  MemoryChunk::MainThreadFlags trusted_flags;
+  if (!chunk_info->optional_metadata) {
+    chunk_info->optional_metadata = malloc(sizeof(PageMetadata));
+  }
+  metadata = new (chunk_info->optional_metadata) PageMetadata(
+      isolate_->heap(), space, chunk_info->size, chunk_info->area_start,
+      chunk_info->area_end, std::move(chunk_info->reservation), executable,
+      &trusted_flags);
+  if (executable) {
+    RwxMemoryWriteScope scope("Initialize a new MemoryChunk.");
+    new (chunk_info->chunk) MemoryChunk(trusted_flags, metadata);
+#ifdef DEBUG
+    RegisterExecutableMemoryChunk(metadata);
+#endif  // DEBUG
+  } else {
+    new (chunk_info->chunk) MemoryChunk(trusted_flags, metadata);
+  }
+
+  DCHECK(metadata->IsLivenessClear());
+  space->InitializePage(metadata);
+  RecordMemoryChunkCreated(metadata);
+  return metadata;
+}
+
+LargePageMetadata* MemoryAllocator::AllocateLargePageAt(
+    LargeObjectSpace* space, Address address, size_t page_size,
+    Executability executable) {
+  std::optional<MemoryChunkAllocationResult> chunk_info;
+
+  if (IsPagePoolSupportedForLargeSpace(space)) {
+    chunk_info = TryAllocateUninitializedLargePageFromPool(space, page_size);
+  }
+
+  if (!chunk_info) {
+    chunk_info =
+        AllocateUninitializedChunkAt(space, page_size, executable, address,
+                                     PageSize::kLarge, AllocationHint());
+  }
+
+  if (!chunk_info) {
+    return nullptr;
+  }
+
+  LargePageMetadata* metadata;
+  MemoryChunk::MainThreadFlags trusted_flags;
+  if (!chunk_info->optional_metadata) {
+    chunk_info->optional_metadata = malloc(sizeof(LargePageMetadata));
+  }
+
+  metadata = new (chunk_info->optional_metadata) LargePageMetadata(
+      isolate_->heap(), space, chunk_info->size, chunk_info->area_start,
+      chunk_info->area_end, std::move(chunk_info->reservation), executable,
+      &trusted_flags);
+  if (executable) {
+    RwxMemoryWriteScope scope("Initialize a new MemoryChunk.");
+    new (chunk_info->chunk) MemoryChunk(trusted_flags, metadata);
+#ifdef DEBUG
+    RegisterExecutableMemoryChunk(metadata);
+#endif  // DEBUG
+  } else {
+    new (chunk_info->chunk) MemoryChunk(trusted_flags, metadata);
+  }
+
+  RecordMemoryChunkCreated(metadata);
+  return metadata;
+}
+#endif  // V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+
 LargePageMetadata* MemoryAllocator::AllocateLargePage(LargeObjectSpace* space,
                                                       size_t object_size,
                                                       Executability executable,

--- a/src/heap/memory-allocator.h
+++ b/src/heap/memory-allocator.h
@@ -100,6 +100,16 @@ class MemoryAllocator final {
       LargeObjectSpace* space, size_t object_size, Executability executable,
       AllocationHint hint);
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  V8_EXPORT_PRIVATE PageMetadata* AllocatePageAt(Space* space,
+                                                 Executability executable,
+                                                 Address start);
+
+  V8_EXPORT_PRIVATE LargePageMetadata* AllocateLargePageAt(
+      LargeObjectSpace* space, Address address, size_t page_size,
+      Executability executable);
+#endif
+
   bool ResizeLargePage(LargePageMetadata* page, size_t old_object_size,
                        size_t new_object_size);
 

--- a/src/heap/memory-chunk.cc
+++ b/src/heap/memory-chunk.cc
@@ -60,6 +60,21 @@ MemoryChunk::MemoryChunk(MainThreadFlags flags, MemoryChunkMetadata* metadata)
 }
 
 #ifdef V8_ENABLE_SANDBOX
+
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+// static
+void MemoryChunk::UpdateMPT(Address chunk_address,
+                            MemoryChunkMetadata* metadata) {
+  auto metadata_index = MetadataTableIndex(chunk_address);
+  IsolateGroup::MemoryChunkMetadataTableEntry* metadata_pointer_table =
+      MetadataTableAddress();
+  DCHECK_IMPLIES(metadata_pointer_table[metadata_index].metadata() != nullptr,
+                 metadata_pointer_table[metadata_index].metadata() == metadata);
+  metadata_pointer_table[metadata_index].SetMetadata(
+      metadata, metadata->heap()->isolate());
+}
+#endif
+
 // static
 void MemoryChunk::ClearMetadataPointer(MemoryChunkMetadata* metadata) {
   uint32_t metadata_index = MetadataTableIndex(metadata->ChunkAddress());

--- a/src/heap/memory-chunk.h
+++ b/src/heap/memory-chunk.h
@@ -160,6 +160,11 @@ class V8_EXPORT_PRIVATE MemoryChunk final {
   V8_INLINE const MemoryChunkMetadata* Metadata(const Isolate* isolate) const;
 
   V8_INLINE MemoryChunkMetadata* Metadata();
+
+#if V8_ENABLE_SANDBOX && V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  V8_INLINE uint32_t MetadataIndex() const { return metadata_index_; }
+#endif
+
   V8_INLINE const MemoryChunkMetadata* Metadata() const;
 
   V8_INLINE MemoryChunkMetadata* MetadataNoIsolateCheck();
@@ -200,6 +205,12 @@ class V8_EXPORT_PRIVATE MemoryChunk final {
   V8_INLINE MainThreadFlags GetFlags() const {
     return untrusted_main_thread_flags_;
   }
+
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  V8_INLINE void SetFlags(MainThreadFlags flags) {
+    untrusted_main_thread_flags_ = flags;
+  }
+#endif
 
   // Emits a memory barrier. For TSAN builds the other thread needs to perform
   // MemoryChunk::SynchronizedLoad() to simulate the barrier.

--- a/src/heap/memory-chunk.h
+++ b/src/heap/memory-chunk.h
@@ -133,6 +133,10 @@ class V8_EXPORT_PRIVATE MemoryChunk final {
 
   MemoryChunk(MainThreadFlags flags, MemoryChunkMetadata* metadata);
 
+#if V8_ENABLE_SANDBOX && V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  static void UpdateMPT(Address chunk_address, MemoryChunkMetadata* metadata);
+#endif
+
   V8_INLINE Address address() const { return reinterpret_cast<Address>(this); }
 
   static constexpr Address BaseAddress(Address a) {

--- a/src/heap/mutable-page-metadata.cc
+++ b/src/heap/mutable-page-metadata.cc
@@ -19,6 +19,10 @@
 #include "src/heap/spaces.h"
 #include "src/objects/heap-object.h"
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+#include "src/heap/remembered-set.h"
+#endif
+
 namespace v8::internal {
 
 MutablePageMetadata::MutablePageMetadata(Heap* heap, BaseSpace* space,
@@ -210,6 +214,94 @@ void MutablePageMetadata::ReleaseAllocatedMemoryNeededForWritableChunk() {
 void MutablePageMetadata::ReleaseAllAllocatedMemory() {
   ReleaseAllocatedMemoryNeededForWritableChunk();
 }
+
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+void MutablePageMetadata::CopyStateFrom(MutablePageMetadata* original_page,
+                                        const VirtualMemoryCage* original_cage,
+                                        const VirtualMemoryCage* cloned_cage) {
+  // Copy slot_set_.
+  for (int i = 0; i < NUMBER_OF_REMEMBERED_SET_TYPES; ++i) {
+    if (!original_page->slot_set_[i]) {
+      continue;
+    }
+
+    SlotSet* original_slot_set = original_page->slot_set_[i];
+    SlotSet* new_slot_set = AllocateSlotSet(static_cast<RememberedSetType>(i));
+    const auto callback = [this, new_slot_set, original_cage,
+                           cloned_cage](MaybeObjectSlot slot) {
+      // TODO(dbezhetskov): since internal representation is based on
+      // offset, cloning could be done without remapping.
+      Address cloned_slot_address =
+          original_cage->Rebase(slot.address(), cloned_cage);
+      new_slot_set
+          ->Insert<SlotSet::ConvertAccessMode<AccessMode::NON_ATOMIC>()>(
+              Offset(cloned_slot_address));
+      return KEEP_SLOT;
+    };
+
+    RememberedSetOperations::template Iterate<AccessMode::NON_ATOMIC,
+                                              decltype(callback)>(
+        original_slot_set, original_page, callback,
+        SlotSet::KEEP_EMPTY_BUCKETS);
+    slot_set_[i] = new_slot_set;
+  }
+
+  // Copy typed_slot_set_.
+  for (int i = 0; i < NUMBER_OF_REMEMBERED_SET_TYPES; ++i) {
+    if (!original_page->typed_slot_set_[i]) {
+      continue;
+    }
+    TypedSlotSet* original_typed_slot_set = original_page->typed_slot_set_[i];
+    TypedSlotSet* new_typed_slot_set =
+        AllocateTypedSlotSet(static_cast<RememberedSetType>(i));
+    original_typed_slot_set->Iterate(
+        [this, new_typed_slot_set, original_cage, cloned_cage](
+            SlotType slot_type, Address slot) {
+          Address cloned_slot_address =
+              original_cage->Rebase(slot, cloned_cage);
+          new_typed_slot_set->Insert(
+              slot_type, static_cast<uint32_t>(Offset(cloned_slot_address)));
+          return KEEP_SLOT;
+        },
+        TypedSlotSet::KEEP_EMPTY_CHUNKS);
+    typed_slot_set_[i] = new_typed_slot_set;
+  }
+
+  // Copy main thread flags.
+  trusted_main_thread_flags_ = original_page->trusted_main_thread_flags_;
+  Chunk()->SetFlags(original_page->Chunk()->GetFlags());
+
+  // Copy external_backing_store_bytes_.
+  for (int i = 0; i < static_cast<int>(ExternalBackingStoreType::kNumValues);
+       ++i) {
+    external_backing_store_bytes_[i].store(
+        original_page->external_backing_store_bytes_[i].load());
+  }
+
+  // Copy active_system_pages_.
+  if (active_system_pages_) {
+    *active_system_pages_ = *original_page->active_system_pages_;
+  }
+
+  // Copy marking_bitmap_.
+  marking_bitmap_ = original_page->marking_bitmap_;
+
+  // Copy live_byte_count_.
+  live_byte_count_.store(original_page->live_byte_count_.load());
+
+  // Copy concurrent_sweeping_.
+  concurrent_sweeping_.store(original_page->concurrent_sweeping_.load());
+
+  // Copy marking_progress_tracker_.
+  marking_progress_tracker_.CloneFrom(original_page->marking_progress_tracker_);
+}
+
+void MutablePageMetadata::CopyBytesStatsFrom(
+    MutablePageMetadata* original_page) {
+  allocated_bytes_ = original_page->allocated_bytes_;
+  wasted_memory_ = original_page->wasted_memory_;
+}
+#endif
 
 SlotSet* MutablePageMetadata::AllocateSlotSet(RememberedSetType type) {
   SlotSet* new_slot_set = SlotSet::Allocate(BucketsInSlotSet());

--- a/src/heap/mutable-page-metadata.h
+++ b/src/heap/mutable-page-metadata.h
@@ -286,6 +286,14 @@ class MutablePageMetadata : public MemoryChunkMetadata {
 
   bool IsLivenessClear() const;
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  void CopyStateFrom(MutablePageMetadata* original_page,
+                     const VirtualMemoryCage* original_cage,
+                     const VirtualMemoryCage* cloned_cage);
+
+  void CopyBytesStatsFrom(MutablePageMetadata* original_page);
+#endif
+
  protected:
   MutablePageMetadata(Heap* heap, BaseSpace* space, size_t size,
                       Address area_start, Address area_end,

--- a/src/heap/new-spaces.cc
+++ b/src/heap/new-spaces.cc
@@ -46,8 +46,12 @@ namespace internal {
 PageMetadata* SemiSpace::InitializePage(MutablePageMetadata* mutable_page) {
   bool in_to_space = (id() != kFromSpace);
   MemoryChunk* chunk = mutable_page->Chunk();
-  mutable_page->SetFlagNonExecutable(in_to_space ? MemoryChunk::TO_PAGE
-                                                 : MemoryChunk::FROM_PAGE);
+  if (!heap_->is_clone_heap_construction()) {
+    // We don't need to set flags because for cloned chunks
+    // flags was set up as part of the original chunk initialization.
+    mutable_page->SetFlagNonExecutable(in_to_space ? MemoryChunk::TO_PAGE
+                                                   : MemoryChunk::FROM_PAGE);
+  }
   PageMetadata* page = PageMetadata::cast(mutable_page);
   page->list_node().Initialize();
   CHECK(page->IsLivenessClear());

--- a/src/heap/new-spaces.cc
+++ b/src/heap/new-spaces.cc
@@ -7,6 +7,10 @@
 #include <atomic>
 #include <optional>
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+#include <vector>
+#endif
+
 #include "src/base/logging.h"
 #include "src/base/macros.h"
 #include "src/common/globals.h"
@@ -136,6 +140,24 @@ bool SemiSpace::AllocateFreshPage() {
                                static_cast<int>(new_page->area_size()));
   return true;
 }
+
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+bool SemiSpace::AllocateFreshPageAt(Address address) {
+  PageMetadata* new_page =
+      heap()->memory_allocator()->AllocatePageAt(this, NOT_EXECUTABLE, address);
+  if (new_page == nullptr) {
+    return false;
+  }
+  memory_chunk_list_.PushBack(new_page);
+  IncrementCommittedPhysicalMemory(new_page->CommittedPhysicalMemory());
+  AccountCommitted(PageMetadata::kPageSize);
+
+  current_page_ = new_page;
+  base::AsAtomicWord::Relaxed_Store(
+      &current_capacity_, current_capacity_ + PageMetadata::kPageSize);
+  return true;
+}
+#endif
 
 void SemiSpace::RewindPages(int num_pages) {
   DCHECK_GT(num_pages, 0);
@@ -408,6 +430,11 @@ void SemiSpace::MoveQuarantinedPage(PageMetadata* metadata) {
 NewSpace::NewSpace(Heap* heap)
     : SpaceWithLinearArea(heap, NEW_SPACE, nullptr) {}
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+NewSpace::NewSpace(Heap* heap, NewSpace* original)
+    : SpaceWithLinearArea(heap, original, NEW_SPACE, nullptr) {}
+#endif
+
 void NewSpace::PromotePageToOldSpace(PageMetadata* page, FreeMode free_mode) {
   DCHECK(page->will_be_promoted());
   DCHECK(page->Chunk()->InYoungGeneration());
@@ -443,6 +470,134 @@ SemiSpaceNewSpace::SemiSpaceNewSpace(Heap* heap,
   DCHECK_LE(minimum_capacity_, target_capacity_);
   DCHECK_LE(target_capacity_, maximum_capacity_);
 }
+
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+SemiSpaceNewSpace::SemiSpaceNewSpace(Heap* heap,
+                                     SemiSpaceNewSpace* original_space)
+    : NewSpace(heap, original_space),
+      to_space_(heap, kToSpace),
+      from_space_(heap, kFromSpace),
+      minimum_capacity_(original_space->minimum_capacity_),
+      maximum_capacity_(original_space->maximum_capacity_),
+      target_capacity_(original_space->target_capacity_) {
+  // Recreate remapped clones of the original pages.
+  const auto* original_cage =
+      original_space->heap()->isolate()->isolate_group()->GetPtrComprCage();
+  const auto* cloned_cage = heap->isolate()->isolate_group()->GetPtrComprCage();
+  const auto rebase = [original_cage, cloned_cage](Address address) {
+    if (address == kNullAddress) {
+      return address;
+    }
+    return original_cage->Rebase(address, cloned_cage);
+  };
+
+  std::vector<PageMetadata*> original_to_space_pages;
+  PageMetadata* cloned_to_space_current_page = nullptr;
+  for (PageMetadata* original_page : original_space->to_space()) {
+    DCHECK(!original_page->Chunk()->IsLargePage());
+    Address page_base = rebase(original_page->ChunkAddress());
+    CHECK(AddToSpacePageAt(page_base));
+    PageMetadata* cloned_page = to_space_.current_page();
+    cloned_page->CopyStateFrom(original_page, original_cage, cloned_cage);
+    DCHECK_EQ(cloned_page->allocated_bytes(), original_page->allocated_bytes());
+    DCHECK_EQ(cloned_page->wasted_memory(), original_page->wasted_memory());
+
+    if (original_page == original_space->to_space_.current_page()) {
+      cloned_to_space_current_page = cloned_page;
+    }
+    original_to_space_pages.push_back(original_page);
+  }
+  DCHECK_IMPLIES(original_space->to_space_.current_page(),
+                 cloned_to_space_current_page);
+  to_space_.current_page_ = cloned_to_space_current_page;
+
+  std::vector<PageMetadata*> original_from_space_pages;
+  PageMetadata* cloned_from_space_current_page = nullptr;
+  for (PageMetadata* original_page : original_space->from_space()) {
+    DCHECK(!original_page->Chunk()->IsLargePage());
+    Address page_base = rebase(original_page->ChunkAddress());
+    CHECK(AddFromSpacePageAt(page_base));
+    PageMetadata* cloned_page = from_space_.current_page();
+    cloned_page->CopyStateFrom(original_page, original_cage, cloned_cage);
+    DCHECK_EQ(cloned_page->allocated_bytes(), original_page->allocated_bytes());
+    DCHECK_EQ(cloned_page->wasted_memory(), original_page->wasted_memory());
+
+    if (original_page == original_space->from_space_.current_page()) {
+      cloned_from_space_current_page = cloned_page;
+    }
+    original_from_space_pages.push_back(original_page);
+  }
+  DCHECK_IMPLIES(original_space->from_space_.current_page(),
+                 cloned_from_space_current_page);
+  from_space_.current_page_ = cloned_from_space_current_page;
+
+  DCHECK(!original_space->free_list());
+  DCHECK(!original_space->to_space_.free_list());
+  DCHECK(!original_space->from_space_.free_list());
+
+  // TODO(dbezhetskov): check if I need this, or it could be replaced by DCHECK.
+  allocation_top_ = rebase(original_space->allocation_top_);
+  age_mark_ = rebase(original_space->age_mark_);
+  quarantined_size_ = original_space->quarantined_size_;
+  size_after_last_gc_ = original_space->size_after_last_gc_;
+  DCHECK_EQ(to_space_.quarantined_pages_count_,
+            original_space->to_space_.quarantined_pages_count_);
+  to_space_.committed_physical_memory_ =
+      original_space->to_space().committed_physical_memory_;
+  from_space_.committed_physical_memory_ =
+      original_space->from_space().committed_physical_memory_;
+
+#ifdef DEBUG
+  size_t i = 0;
+  for (PageMetadata* cloned_page : to_space_) {
+    PageMetadata* original_page = original_to_space_pages[i];
+    Address new_area_start = rebase(original_page->area_start());
+    Address new_area_end = rebase(original_page->area_end());
+    DCHECK_EQ(cloned_page->area_start(), new_area_start);
+    DCHECK_EQ(cloned_page->area_end(), new_area_end);
+    DCHECK_EQ(cloned_page->size(), original_page->size());
+    ++i;
+  }
+
+  size_t j = 0;
+  for (PageMetadata* cloned_page : from_space_) {
+    PageMetadata* original_page = original_from_space_pages[j];
+    Address new_area_start = rebase(original_page->area_start());
+    Address new_area_end = rebase(original_page->area_end());
+    DCHECK_EQ(cloned_page->area_start(), new_area_start);
+    DCHECK_EQ(cloned_page->area_end(), new_area_end);
+    DCHECK_EQ(cloned_page->size(), original_page->size());
+    ++j;
+  }
+
+  if (to_space_.current_page()) {
+    DCHECK_EQ(to_space_.page_low(),
+              rebase(original_space->to_space_.page_low()));
+    DCHECK_EQ(to_space_.page_high(),
+              rebase(original_space->to_space_.page_high()));
+    DCHECK_EQ(to_space_.first_page()->ChunkAddress(),
+              rebase(original_space->to_space_.first_page()->ChunkAddress()));
+    DCHECK_EQ(to_space_.last_page()->ChunkAddress(),
+              rebase(original_space->to_space_.last_page()->ChunkAddress()));
+  }
+
+  if (from_space_.current_page()) {
+    DCHECK_EQ(from_space_.page_low(),
+              rebase(original_space->from_space_.page_low()));
+    DCHECK_EQ(from_space_.page_high(),
+              rebase(original_space->from_space_.page_high()));
+    DCHECK_EQ(from_space_.first_page()->ChunkAddress(),
+              rebase(original_space->from_space_.first_page()->ChunkAddress()));
+    DCHECK_EQ(from_space_.last_page()->ChunkAddress(),
+              rebase(original_space->from_space_.last_page()->ChunkAddress()));
+  }
+
+  to_space_.current_capacity_ = original_space->to_space_.current_capacity();
+  from_space_.current_capacity_ =
+      original_space->from_space_.current_capacity();
+#endif
+}
+#endif
 
 void SemiSpaceNewSpace::Grow(size_t new_capacity) {
   heap()->safepoint()->AssertActive();
@@ -515,6 +670,26 @@ bool SemiSpaceNewSpace::AddFreshPage() {
   }
   return false;
 }
+
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+bool SemiSpaceNewSpace::AddToSpacePageAt(Address address) {
+  if (to_space_.AllocateFreshPageAt(address)) {
+    ResetAllocationTopToCurrentPageStart();
+    Address end = to_space_.page_high();
+    IncrementAllocationTop(end);
+    return true;
+  }
+  return false;
+}
+
+bool SemiSpaceNewSpace::AddFromSpacePageAt(Address address) {
+  if (from_space_.AllocateFreshPageAt(address)) {
+    return true;
+  }
+  return false;
+}
+#endif
+
 std::optional<std::pair<Address, Address>>
 SemiSpaceNewSpace::AllocateOnNewPageBeyondCapacity(
     int size_in_bytes, AllocationAlignment alignment) {

--- a/src/heap/new-spaces.h
+++ b/src/heap/new-spaces.h
@@ -144,6 +144,10 @@ class SemiSpace final : public Space {
  private:
   bool AllocateFreshPage();
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  bool AllocateFreshPageAt(Address address);
+#endif
+
   void RewindPages(int num_pages);
 
   // Iterates all pages and properly initializes page flags for this space.
@@ -189,6 +193,10 @@ class NewSpace : NON_EXPORTED_BASE(public SpaceWithLinearArea) {
   using const_iterator = ConstPageIterator;
 
   explicit NewSpace(Heap* heap);
+
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  NewSpace(Heap* heap, NewSpace* original);
+#endif
 
   base::Mutex* mutex() { return &mutex_; }
 
@@ -263,6 +271,10 @@ class V8_EXPORT_PRIVATE SemiSpaceNewSpace final : public NewSpace {
   SemiSpaceNewSpace(Heap* heap, size_t initial_semispace_capacity,
                     size_t min_semispace_capacity_,
                     size_t max_semispace_capacity);
+
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  SemiSpaceNewSpace(Heap* heap, SemiSpaceNewSpace* original_space);
+#endif
 
   ~SemiSpaceNewSpace() final = default;
 
@@ -356,6 +368,11 @@ class V8_EXPORT_PRIVATE SemiSpaceNewSpace final : public NewSpace {
   // are no pages, or the current page is already empty), or true
   // if successful.
   bool AddFreshPage();
+
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  bool AddToSpacePageAt(Address address);
+  bool AddFromSpacePageAt(Address address);
+#endif
 
   bool AddParkedAllocationBuffer(int size_in_bytes,
                                  AllocationAlignment alignment);

--- a/src/heap/paged-spaces-inl.h
+++ b/src/heap/paged-spaces-inl.h
@@ -93,14 +93,18 @@ size_t PagedSpaceBase::FreeInternal(Address start, size_t size_in_bytes) {
   if (executable_) {
     WritableJitPage jit_page(start, size_in_bytes);
     WritableFreeSpace free_space = jit_page.FreeRange(start, size_in_bytes);
-    heap()->CreateFillerObjectAtBackground(free_space);
+    if (!heap()->is_clone_heap_construction()) {
+      heap()->CreateFillerObjectAtBackground(free_space);
+    }
     wasted =
         free_list_->Free(heap()->isolate(), free_space,
                          during_sweep ? kDoNotLinkCategory : kLinkCategory);
   } else {
     WritableFreeSpace free_space =
         WritableFreeSpace::ForNonExecutableMemory(start, size_in_bytes);
-    heap()->CreateFillerObjectAtBackground(free_space);
+    if (!heap()->is_clone_heap_construction()) {
+      heap()->CreateFillerObjectAtBackground(free_space);
+    }
     wasted =
         free_list_->Free(heap()->isolate(), free_space,
                          during_sweep ? kDoNotLinkCategory : kLinkCategory);

--- a/src/heap/paged-spaces.cc
+++ b/src/heap/paged-spaces.cc
@@ -76,6 +76,83 @@ PagedSpaceBase::PagedSpaceBase(Heap* heap, AllocationSpace space,
   accounting_stats_.Clear();
 }
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+PagedSpaceBase::PagedSpaceBase(Heap* heap, PagedSpaceBase* original_space,
+                               AllocationSpace space, Executability executable,
+                               std::unique_ptr<FreeList> free_list,
+                               CompactionSpaceKind compaction_space_kind)
+    : SpaceWithLinearArea(heap, space, std::move(free_list)),
+      executable_(executable),
+      compaction_space_kind_(compaction_space_kind) {
+  // Allocate each page at the same offset from its cage base as the
+  // corresponding original page. Invariant:
+  //   original_page_start - original_cage_base == new_page_start -
+  //   new_cage_base.
+  const VirtualMemoryCage* original_cage = original_space->GetCage();
+  const VirtualMemoryCage* cloned_cage = GetCage();
+  for (PageMetadata* original_page : *original_space) {
+#ifdef DEBUG
+    Address new_area_start =
+        original_cage->Rebase(original_page->area_start(), cloned_cage);
+    Address new_area_end =
+        original_cage->Rebase(original_page->area_end(), cloned_cage);
+#endif
+    Address original_page_base = original_page->Chunk()->address();
+    Address cloned_page_base =
+        original_cage->Rebase(original_page_base, cloned_cage);
+
+    DCHECK(!original_page->Chunk()->IsLargePage());
+    PageMetadata* cloned_page = heap->memory_allocator()->AllocatePageAt(
+        this, executable, cloned_page_base);
+    cloned_page->CopyStateFrom(original_page, original_cage, cloned_cage);
+    DCHECK(cloned_page);
+
+    if (IsAnyCodeSpace(space)) {
+      ThreadIsolation::CloneJitAllocationsForPage(
+          original_page_base, original_cage, cloned_page_base, cloned_cage,
+          original_page->size());
+    }
+
+    // Check that a newly allocated page corresponds to
+    // the same offsets.
+    DCHECK_EQ(cloned_page->area_start(), new_area_start);
+    DCHECK_EQ(cloned_page->area_end(), new_area_end);
+    DCHECK_EQ(cloned_page->size(), original_page->size());
+
+    ConcurrentAllocationMutex guard(this);
+    AddPage(cloned_page);
+    NotifyNewPage(cloned_page);
+
+    cloned_page->CopyBytesStatsFrom(original_page);
+    accounting_stats_.CloneAndRebindFrom(
+        original_space->accounting_stats_,
+        heap->isolate()->isolate_group()->metadata_pointer_table());
+    DCHECK_EQ(accounting_stats_.AllocatedOnPage(cloned_page),
+              original_space->accounting_stats_.AllocatedOnPage(original_page));
+    DCHECK_EQ(cloned_page->allocated_bytes(), original_page->allocated_bytes());
+    DCHECK_EQ(cloned_page->wasted_memory(), original_page->wasted_memory());
+  }
+
+  area_size_ = MemoryChunkLayout::AllocatableMemoryInMemoryChunk(space);
+  DCHECK_EQ(area_size_, original_space->area_size_);
+  DCHECK_EQ(accounting_stats_.Size(), original_space->accounting_stats_.Size());
+  DCHECK_EQ(accounting_stats_.Capacity(),
+            original_space->accounting_stats_.Capacity());
+  committed_physical_memory_.store(
+      original_space->committed_physical_memory_.load());
+  size_at_last_gc_ = original_space->size_at_last_gc_;
+
+  if (first_page() && last_page()) {
+    DCHECK_EQ(first_page()->ChunkAddress(),
+              original_cage->Rebase(
+                  original_space->first_page()->ChunkAddress(), cloned_cage));
+    DCHECK_EQ(last_page()->ChunkAddress(),
+              original_cage->Rebase(original_space->last_page()->ChunkAddress(),
+                                    cloned_cage));
+  }
+}
+#endif
+
 PageMetadata* PagedSpaceBase::InitializePage(
     MutablePageMetadata* mutable_page_metadata) {
   MemoryChunk* chunk = mutable_page_metadata->Chunk();

--- a/src/heap/paged-spaces.h
+++ b/src/heap/paged-spaces.h
@@ -120,6 +120,12 @@ class V8_EXPORT_PRIVATE PagedSpaceBase
                  std::unique_ptr<FreeList> free_list,
                  CompactionSpaceKind compaction_space_kind);
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  PagedSpaceBase(Heap* heap, PagedSpaceBase* original_space, AllocationSpace id,
+                 Executability executable, std::unique_ptr<FreeList> free_list,
+                 CompactionSpaceKind compaction_space_kind);
+#endif
+
   ~PagedSpaceBase() override { TearDown(); }
 
   // Checks whether an object/address is in this space.
@@ -366,6 +372,14 @@ class V8_EXPORT_PRIVATE PagedSpace : public PagedSpaceBase {
       : PagedSpaceBase(heap, id, executable, std::move(free_list),
                        compaction_space_kind) {}
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  PagedSpace(Heap* heap, PagedSpace* original, AllocationSpace id,
+             Executability executable, std::unique_ptr<FreeList> free_list,
+             CompactionSpaceKind compaction_space_kind)
+      : PagedSpaceBase(heap, original, id, executable, std::move(free_list),
+                       compaction_space_kind) {}
+#endif
+
   AllocatorPolicy* CreateAllocatorPolicy(MainAllocator* allocator) final;
 };
 
@@ -449,6 +463,12 @@ class V8_EXPORT_PRIVATE OldSpace : public PagedSpace {
       : PagedSpace(heap, OLD_SPACE, NOT_EXECUTABLE, FreeList::CreateFreeList(),
                    CompactionSpaceKind::kNone) {}
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  OldSpace(Heap* heap, OldSpace* original)
+      : PagedSpace(heap, original, OLD_SPACE, NOT_EXECUTABLE,
+                   FreeList::CreateFreeList(), CompactionSpaceKind::kNone) {}
+#endif
+
   void AddPromotedPage(PageMetadata* page, FreeMode free_mode);
 
   size_t ExternalBackingStoreBytes(ExternalBackingStoreType type) const final {
@@ -515,6 +535,11 @@ class CodeSpace final : public PagedSpace {
   explicit CodeSpace(Heap* heap)
       : PagedSpace(heap, CODE_SPACE, EXECUTABLE, FreeList::CreateFreeList(),
                    CompactionSpaceKind::kNone) {}
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  CodeSpace(Heap* heap, CodeSpace* original)
+      : PagedSpace(heap, original, CODE_SPACE, EXECUTABLE,
+                   FreeList::CreateFreeList(), CompactionSpaceKind::kNone) {}
+#endif
 };
 
 // -----------------------------------------------------------------------------
@@ -548,6 +573,12 @@ class TrustedSpace final : public PagedSpace {
   explicit TrustedSpace(Heap* heap)
       : PagedSpace(heap, TRUSTED_SPACE, NOT_EXECUTABLE,
                    FreeList::CreateFreeList(), CompactionSpaceKind::kNone) {}
+
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  TrustedSpace(Heap* heap, TrustedSpace* original)
+      : PagedSpace(heap, original, TRUSTED_SPACE, NOT_EXECUTABLE,
+                   FreeList::CreateFreeList(), CompactionSpaceKind::kNone) {}
+#endif
 
   size_t ExternalBackingStoreBytes(ExternalBackingStoreType type) const final {
     if (type == ExternalBackingStoreType::kArrayBuffer) return 0;

--- a/src/heap/spaces-inl.h
+++ b/src/heap/spaces-inl.h
@@ -58,6 +58,17 @@ void Space::MoveExternalBackingStoreBytes(ExternalBackingStoreType type,
       &(to->external_backing_store_bytes_[static_cast<int>(type)]), amount);
 }
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+const VirtualMemoryCage* Space::GetCage() const {
+  if (IsAnyTrustedSpace(identity())) {
+    return heap()->isolate()->isolate_group()->GetTrustedPtrComprCage();
+  } else if (IsAnyCodeSpace(identity())) {
+    return heap()->isolate()->isolate_group()->GetCodeRange();
+  }
+  return heap()->isolate()->isolate_group()->GetPtrComprCage();
+}
+#endif
+
 PageRange::PageRange(PageMetadata* page) : PageRange(page, page->next_page()) {}
 ConstPageRange::ConstPageRange(const PageMetadata* page)
     : ConstPageRange(page, page->next_page()) {}

--- a/src/heap/spaces.cc
+++ b/src/heap/spaces.cc
@@ -40,6 +40,14 @@ SpaceWithLinearArea::SpaceWithLinearArea(Heap* heap, AllocationSpace id,
                                          std::unique_ptr<FreeList> free_list)
     : Space(heap, id, std::move(free_list)) {}
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+SpaceWithLinearArea::SpaceWithLinearArea(Heap* heap,
+                                         SpaceWithLinearArea* original,
+                                         AllocationSpace id,
+                                         std::unique_ptr<FreeList> free_list)
+    : Space(heap, original, id, std::move(free_list)) {}
+#endif
+
 SpaceIterator::SpaceIterator(Heap* heap)
     : heap_(heap), current_space_(FIRST_MUTABLE_SPACE) {}
 

--- a/src/heap/spaces.h
+++ b/src/heap/spaces.h
@@ -72,6 +72,21 @@ class V8_EXPORT_PRIVATE Space : public BaseSpace {
   Space(Heap* heap, AllocationSpace id, std::unique_ptr<FreeList> free_list)
       : BaseSpace(heap, id), free_list_(std::move(free_list)) {}
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  Space(Heap* heap, Space* original, AllocationSpace id,
+        std::unique_ptr<FreeList> free_list)
+      : BaseSpace(heap, id, original), free_list_(std::move(free_list)) {
+    // Copy external_backing_store_bytes_.
+    for (int i = 0; i < static_cast<int>(ExternalBackingStoreType::kNumValues);
+         ++i) {
+      external_backing_store_bytes_[i].store(
+          original->external_backing_store_bytes_[i].load());
+    }
+  }
+
+  inline const VirtualMemoryCage* GetCage() const;
+#endif
+
   ~Space() override = default;
 
   Space(const Space&) = delete;
@@ -219,6 +234,11 @@ class V8_EXPORT_PRIVATE SpaceWithLinearArea : public Space {
   // new MainAllocator instance.
   SpaceWithLinearArea(Heap* heap, AllocationSpace id,
                       std::unique_ptr<FreeList> free_list);
+
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  SpaceWithLinearArea(Heap* heap, SpaceWithLinearArea* original,
+                      AllocationSpace id, std::unique_ptr<FreeList> free_list);
+#endif
 
   virtual AllocatorPolicy* CreateAllocatorPolicy(MainAllocator* allocator) = 0;
 

--- a/src/heap/zapping.h
+++ b/src/heap/zapping.h
@@ -16,6 +16,12 @@ namespace v8::internal::heap {
 
 // Zapping is needed for verify heap, and always done in debug builds.
 inline bool ShouldZapGarbage() {
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  // During page initialization we sometimes
+  // call this for cloned pages and obviously
+  // we don't want to spoil the original content.
+  return false;
+#endif
 #ifdef DEBUG
   return true;
 #else

--- a/src/init/isolate-group.cc
+++ b/src/init/isolate-group.cc
@@ -333,6 +333,28 @@ CodeRange* IsolateGroup::EnsureCodeRange(size_t requested_size) {
   return code_range_.get();
 }
 
+CodeRange* IsolateGroup::EnsureCodeRange(size_t requested_size,
+                                         CodeRange* original) {
+  if (code_range_) {
+    return code_range_.get();
+  }
+  DCHECK(!process_wide_);
+  CodeRange* code_range = new CodeRange();
+  if (!code_range->InitReservation(page_allocator_, requested_size,
+                                   /* immutable */ false, original)) {
+    V8::FatalProcessOutOfMemory(
+        nullptr, "Failed to reserve virtual memory for CodeRange");
+  }
+  code_range_.reset(code_range);
+
+#ifdef V8_EXTERNAL_CODE_SPACE
+  ExternalCodeCompressionScheme::InitBase(
+      ExternalCodeCompressionScheme::PrepareCageBaseAddress(
+          code_range->base()));
+#endif  // V8_EXTERNAL_CODE_SPACE
+  return code_range_.get();
+}
+
 ReadOnlyArtifacts* IsolateGroup::InitializeReadOnlyArtifacts() {
   mutex_.AssertHeld();
   DCHECK(!read_only_artifacts_);

--- a/src/init/isolate-group.h
+++ b/src/init/isolate-group.h
@@ -238,6 +238,7 @@ class V8_EXPORT_PRIVATE IsolateGroup final {
 #endif  // V8_COMPRESS_POINTERS
 
   CodeRange* EnsureCodeRange(size_t requested_size);
+  CodeRange* EnsureCodeRange(size_t requested_size, CodeRange* original);
   CodeRange* GetCodeRange() const { return code_range_.get(); }
 
 #ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES

--- a/src/utils/allocation.h
+++ b/src/utils/allocation.h
@@ -426,6 +426,17 @@ class VirtualMemoryCage {
 
   void Free();
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  Address Rebase(Address ptr, const VirtualMemoryCage* to) const {
+    DCHECK(Contains(ptr));
+    Address rebased_ptr = to->base() + (ptr - base());
+    DCHECK(to->Contains(rebased_ptr));
+    return rebased_ptr;
+  }
+
+  bool Contains(Address address) const { return region().contains(address); }
+#endif
+
  protected:
   Address base_ = kNullAddress;
   size_t size_ = 0;


### PR DESCRIPTION
Introduce cloning routines for the V8 heap, covering all major spaces: 
new (young) space, old space, code space, trusted space, and large object spaces.

This is enabled by the ability to allocate pages at specific addresses inside a preallocated pointer cage. 
Because memory is already preallocated and initialized by the original heap, cloning only needs to reconstruct the internal metadata for each space. This is done via the memory allocator and newly added cloning constructors across the spaces (and LocalHeap).