### PR TITLE
Part 4: Introduce read-only heap clone routine

### DIFF
--- a/src/heap/memory-allocator.cc
+++ b/src/heap/memory-allocator.cc
@@ -485,7 +485,18 @@ ReadOnlyPageMetadata* MemoryAllocator::AllocateReadOnlyPage(
       isolate_->heap(), space, chunk_info->size, chunk_info->area_start,
       chunk_info->area_end, std::move(chunk_info->reservation));
 
-  new (chunk_info->chunk) MemoryChunk(metadata->InitialFlags(), metadata);
+  if (isolate_->heap()->is_clone_heap_construction()) {
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+    // We don't need to construct memory chunk because we already have one
+    // in memory and it should be with the same data.
+    // There is way to avoid this change and just reset cloned sandbox after
+    // creation and reduce diff with upstream but it will be slower a bit.
+    MemoryChunk::UpdateMPT(reinterpret_cast<Address>(chunk_info->chunk),
+                           metadata);
+#endif
+  } else {
+    new (chunk_info->chunk) MemoryChunk(metadata->InitialFlags(), metadata);
+  }
 
 #ifdef V8_ENABLE_SANDBOX_HARDWARE_SUPPORT
   SandboxHardwareSupport::RegisterReadOnlyMemoryInsideSandbox(

--- a/src/heap/read-only-heap.cc
+++ b/src/heap/read-only-heap.cc
@@ -78,6 +78,101 @@ void ReadOnlyHeap::SetUp(Isolate* isolate,
   }
 }
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+void ReadOnlyHeap::SetUpClone(Isolate* clone_isolate,
+                              const Isolate* original_isolate) {
+  DCHECK_NOT_NULL(clone_isolate);
+
+  IsolateGroup* cloned_group = clone_isolate->isolate_group();
+  IsolateGroup* original_group = original_isolate->isolate_group();
+  original_group->mutex()->AssertHeld();
+  cloned_group->mutex()->AssertHeld();
+  if (!cloned_group->read_only_artifacts()) {
+    // Recreate read-only artifacts since we already have mapped read only pages
+    // in memory.
+    ReadOnlyArtifacts* new_ro_artifacts =
+        cloned_group->InitializeReadOnlyArtifacts();
+    CreateInitialHeapForBootstrapping(clone_isolate, new_ro_artifacts);
+    ReadOnlySpace* cloned_ro_space =
+        new_ro_artifacts->read_only_heap()->read_only_space();
+
+    auto rebase = [original_cage = original_group->GetPtrComprCage(),
+                   cloned_cage =
+                       cloned_group->GetPtrComprCage()](Address address) {
+      if (address == kNullAddress) {
+        return address;
+      }
+      return original_cage->Rebase(address, cloned_cage);
+    };
+
+    // Repeat steps from deserialization but
+    // without real deserialization.
+    for (ReadOnlyPageMetadata* original_page :
+         original_group->read_only_artifacts()->pages()) {
+      Address new_memory_chunk_start =
+          rebase(original_page->Chunk()->address());
+      size_t actual_idx =
+          cloned_ro_space->AllocateNextPageAt(new_memory_chunk_start);
+      DCHECK_EQ(cloned_ro_space->pages_[actual_idx]->area_start(),
+                rebase(original_page->area_start()));
+      cloned_ro_space->InitializePageForDeserialization(
+          cloned_ro_space->pages_[actual_idx],
+          original_page->allocated_bytes());
+    }
+    ReadOnlyRoots(clone_isolate)
+        .InitFromStaticRootsTable(clone_isolate->cage_base());
+    cloned_ro_space->FinalizeSpaceAfterCloning();
+    cloned_ro_space->DetachPagesAndAddToArtifacts(new_ro_artifacts);
+    new_ro_artifacts->ReinstallReadOnlySpace(clone_isolate);
+    new_ro_artifacts->read_only_heap()->read_only_space_ =
+        new_ro_artifacts->shared_read_only_space();
+#ifdef DEBUG
+    new_ro_artifacts->VerifyHeapAndSpaceRelationships(clone_isolate);
+#endif
+    cloned_group->read_only_artifacts()->set_initial_next_unique_sfi_id(
+        clone_isolate->next_unique_sfi_id());
+
+    // Copy with adjusting read only roots.
+    int index = 0;
+    for (Address old_root_address :
+         original_group->shared_read_only_heap()->read_only_roots_) {
+      new_ro_artifacts->read_only_heap()->read_only_roots_[index] =
+          rebase(old_root_address);
+      ++index;
+    }
+    new_ro_artifacts->read_only_heap()->roots_init_complete_ = true;
+
+    // Copy external pointer registry which
+    // is needed for EPT read-only segments initialization.
+    std::vector<ReadOnlyArtifacts::ExternalPointerRegistryEntry> registry =
+        original_group->read_only_artifacts()->external_pointer_registry();
+    new_ro_artifacts->set_external_pointer_registry(std::move(registry));
+
+#ifdef DEBUG
+    ReadOnlySpace* original_ro_space =
+        original_group->shared_read_only_heap()->read_only_space();
+    cloned_ro_space = cloned_group->shared_read_only_heap()->read_only_space();
+    DCHECK_EQ(rebase(original_ro_space->top_), cloned_ro_space->top_);
+    DCHECK_EQ(rebase(original_ro_space->limit_), cloned_ro_space->limit_);
+    DCHECK_EQ(original_ro_space->accounting_stats_.Capacity(),
+              cloned_ro_space->accounting_stats_.Capacity());
+    DCHECK_EQ(original_ro_space->accounting_stats_.Size(),
+              cloned_ro_space->accounting_stats_.Size());
+#endif
+  } else {
+    ReadOnlyArtifacts* artifacts = cloned_group->read_only_artifacts();
+    DCHECK_NOT_NULL(artifacts);
+    clone_isolate->SetUpFromReadOnlyArtifacts(artifacts);
+  }
+
+  cloned_group->read_only_artifacts()->read_only_heap()->InitializeIsolateRoots(
+      clone_isolate);
+  clone_isolate->external_pointer_table().SetUpFromReadOnlyArtifacts(
+      clone_isolate->heap()->read_only_external_pointer_space(),
+      cloned_group->read_only_artifacts());
+}
+#endif  // V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+
 void ReadOnlyHeap::DeserializeIntoIsolate(Isolate* isolate,
                                           SnapshotData* read_only_snapshot_data,
                                           bool can_rehash) {

--- a/src/heap/read-only-heap.h
+++ b/src/heap/read-only-heap.h
@@ -53,6 +53,10 @@ class ReadOnlyHeap final {
   static void SetUp(Isolate* isolate, SnapshotData* read_only_snapshot_data,
                     bool can_rehash);
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  static void SetUpClone(Isolate* isolate, const Isolate* original_isolate);
+#endif
+
   // Indicates that the isolate has been set up and all read-only space objects
   // have been created and will not be written to. This should only be called if
   // a deserializer was not previously provided to Setup. This releases the

--- a/src/heap/read-only-spaces.cc
+++ b/src/heap/read-only-spaces.cc
@@ -512,6 +512,21 @@ size_t ReadOnlyPageMetadata::ShrinkToHighWaterMark() {
   return unused;
 }
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+void ReadOnlyPageMetadata::ShrinkCloneToHighWaterMark() {
+  // It is the same as ShrinkToHighWaterMark
+  // but for clones we don't need to create filler object
+  // because they are already there.
+  Address top = ChunkAddress() + high_water_mark_;
+  DCHECK_LE(top, area_end());
+  size_t unused = RoundDown(static_cast<size_t>(area_end() - top),
+                            MemoryAllocator::GetCommitPageSize());
+  if (unused == 0) return;
+  heap()->memory_allocator()->PartialFreeMemory(
+      this, ChunkAddress() + size() - unused, unused, area_end() - unused);
+}
+#endif
+
 void ReadOnlySpace::ShrinkPages() {
   MemoryChunkMetadata::UpdateHighWaterMark(top_);
   heap()->CreateFillerObjectAt(top_, static_cast<int>(limit_ - top_));
@@ -584,6 +599,18 @@ void ReadOnlySpace::FinalizeSpaceForDeserialization() {
     accounting_stats_.IncreaseAllocatedBytes(page->allocated_bytes(), page);
   }
 }
+
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+void ReadOnlySpace::FinalizeSpaceAfterCloning() {
+  // The ReadOnlyRoots table is now initialized.
+  // Shrink pages, and update accounting stats.
+  for (ReadOnlyPageMetadata* page : pages_) {
+    page->ShrinkCloneToHighWaterMark();
+    accounting_stats_.IncreaseCapacity(page->area_size());
+    accounting_stats_.IncreaseAllocatedBytes(page->allocated_bytes(), page);
+  }
+}
+#endif
 
 }  // namespace internal
 }  // namespace v8

--- a/src/heap/read-only-spaces.h
+++ b/src/heap/read-only-spaces.h
@@ -40,6 +40,10 @@ class ReadOnlyPageMetadata : public MemoryChunkMetadata {
 
   size_t ShrinkToHighWaterMark();
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  void ShrinkCloneToHighWaterMark();
+#endif
+
   // Returns the address for a given offset in this page.
   Address OffsetToAddress(size_t offset) const {
     Address address_in_page = ChunkAddress() + offset;
@@ -241,12 +245,17 @@ class ReadOnlySpace : public BaseSpace {
                                         size_t area_size_in_bytes);
   void FinalizeSpaceForDeserialization();
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  void FinalizeSpaceAfterCloning();
+#endif
+
   void EnsureSpaceForAllocation(int size_in_bytes);
   void FreeLinearAllocationArea();
 
   size_t capacity_ = 0;
 
   friend class Heap;
+  friend class ReadOnlyHeap;
   friend class ReadOnlyHeapImageDeserializer;
 };
 

--- a/src/init/isolate-group.cc
+++ b/src/init/isolate-group.cc
@@ -366,6 +366,15 @@ ReadOnlyArtifacts* IsolateGroup::InitializeReadOnlyArtifacts() {
 std::weak_ptr<PageAllocator> IsolateGroup::GetBackingStorePageAllocator() {
   return sandbox()->page_allocator_weak();
 }
+
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+void IsolateGroup::SetupReadOnlyHeapClone(Isolate* isolate, Isolate* original) {
+  DCHECK_EQ(isolate->isolate_group(), this);
+  base::MutexGuard original_group_guard(original->isolate_group()->mutex());
+  base::MutexGuard cloned_group_guard(&mutex_);
+  ReadOnlyHeap::SetUpClone(isolate, original);
+}
+#endif  // V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
 #endif  // V8_ENABLE_SANDBOX
 
 void IsolateGroup::SetupReadOnlyHeap(Isolate* isolate,

--- a/src/init/isolate-group.h
+++ b/src/init/isolate-group.h
@@ -301,6 +301,10 @@ class V8_EXPORT_PRIVATE IsolateGroup final {
   }
 
   SandboxedArrayBufferAllocatorBase* GetSandboxedArrayBufferAllocator();
+
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  void SetupReadOnlyHeapClone(Isolate* isolate, Isolate* original);
+#endif
 #endif  // V8_ENABLE_SANDBOX
 
   JSDispatchTable* js_dispatch_table() { return &js_dispatch_table_; }


### PR DESCRIPTION
Introduce a cloning routine for the read-only part of the heap.

This part of the pointer cage is shared by all isolates within an isolate group, so it is initialized at the isolate-group level. To create a clone, we recreate all read-only pages by allocating them at offsets within the destination pointer cage that mirror the offsets of the original read-only pages.