### PR TITLE
Part 5: Switch from embedded absolute pointers in code objects to relative compressed offsets

### DIFF
--- a/src/baseline/baseline-assembler.h
+++ b/src/baseline/baseline-assembler.h
@@ -116,6 +116,9 @@ class BaselineAssembler {
   inline void MoveMaybeSmi(Register output, Register source);
   inline void MoveSmi(Register output, Register source);
 
+  inline void MoveTagged(Register output, Handle<HeapObject> value);
+  inline void DecompressTagged(Register output, Register source);
+
   // Push the given values, in the given order. If the stack needs alignment
   // (looking at you Arm64), the stack is padded from the front (i.e. before the
   // first value is pushed).

--- a/src/baseline/baseline-compiler.cc
+++ b/src/baseline/baseline-compiler.cc
@@ -200,7 +200,14 @@ struct ArgumentSettingHelper<Descriptor, ArgIndex, true, Arg, Args...> {
     static_assert(ArgIndex < Descriptor::GetRegisterParameterCount());
     Register target = Descriptor::GetRegisterParameter(ArgIndex);
     CheckSettingDoesntClobber(target, args...);
-    masm->Move(target, arg);
+    if constexpr (!std::is_same_v<std::decay_t<Arg>, Handle<BytecodeArray>> &&
+                  std::is_convertible_v<std::decay_t<Arg>,
+                                        Handle<HeapObject>>) {
+      masm->MoveTagged(target, arg);
+      masm->DecompressTagged(target, target);
+    } else {
+      masm->Move(target, arg);
+    }
     ArgumentSettingHelper<Descriptor, ArgIndex + 1,
                           (ArgIndex + 1 <
                            Descriptor::GetRegisterParameterCount()),
@@ -397,7 +404,13 @@ Tagged<Smi> BaselineCompiler::ConstantSmi(int operand_index) {
 }
 template <typename Type>
 void BaselineCompiler::LoadConstant(Register output, int operand_index) {
-  __ Move(output, Constant<Type>(operand_index));
+  if constexpr (!std::is_same_v<std::decay_t<Type>, BytecodeArray> &&
+                std::is_convertible_v<std::decay_t<Type>, HeapObject>) {
+    __ MoveTagged(output, Constant<Type>(operand_index));
+    __ DecompressTagged(output, output);
+  } else {
+    __ Move(output, Constant<Type>(operand_index));
+  }
 }
 uint32_t BaselineCompiler::Uint(int operand_index) {
   return iterator().GetUnsignedImmediateOperand(operand_index);

--- a/src/baseline/x64/baseline-assembler-x64-inl.h
+++ b/src/baseline/x64/baseline-assembler-x64-inl.h
@@ -230,6 +230,18 @@ void BaselineAssembler::MoveSmi(Register output, Register source) {
   __ mov_tagged(output, source);
 }
 
+void BaselineAssembler::MoveTagged(Register output, Handle<HeapObject> value) {
+#ifdef V8_COMPRESS_POINTERS
+  __ Move(output, value, RelocInfo::COMPRESSED_EMBEDDED_OBJECT);
+#else
+  __ Move(output, value);
+#endif
+}
+
+void BaselineAssembler::DecompressTagged(Register output, Register source) {
+  __ DecompressTagged(output, source);
+}
+
 namespace detail {
 inline void PushSingle(MacroAssembler* masm, RootIndex source) {
   masm->PushRoot(source);

--- a/src/codegen/x64/macro-assembler-x64.cc
+++ b/src/codegen/x64/macro-assembler-x64.cc
@@ -3188,7 +3188,12 @@ void MacroAssembler::JumpIfIsInRange(Register value, unsigned lower_limit,
 }
 
 void MacroAssembler::Push(Handle<HeapObject> source) {
+#ifdef V8_COMPRESS_POINTERS
+  Move(kScratchRegister, source, RelocInfo::COMPRESSED_EMBEDDED_OBJECT);
+  DecompressTagged(kScratchRegister, kScratchRegister);
+#else
   Move(kScratchRegister, source);
+#endif
   Push(kScratchRegister);
 }
 

--- a/src/compiler/backend/x64/code-generator-x64.cc
+++ b/src/compiler/backend/x64/code-generator-x64.cc
@@ -8373,7 +8373,16 @@ void CodeGenerator::AssembleMove(InstructionOperand* source,
         if (IsMaterializableFromRoot(src_object, &index)) {
           __ LoadRoot(dst, index);
         } else {
+#ifdef V8_COMPRESS_POINTERS
+          if (TrustedHeapLayout::InTrustedSpace(*src_object)) {
+            __ Move(dst, src_object);
+          } else {
+            __ Move(dst, src_object, RelocInfo::COMPRESSED_EMBEDDED_OBJECT);
+            __ DecompressTagged(dst, dst);
+          }
+#else
           __ Move(dst, src_object);
+#endif
         }
         break;
       }

--- a/src/heap/heap.cc
+++ b/src/heap/heap.cc
@@ -6620,7 +6620,20 @@ void Heap::SetUpClone(LocalHeap* main_thread_local_heap, Heap* target) {
   nodes_promoted_ = target->nodes_promoted_;
   last_gc_time_ = target->last_gc_time_;
 }
-#endif
+
+void Heap::RebaseAbsolutePointersToTrustedCage(
+    VirtualMemoryCage* original_trusted_cage) {
+  SafepointScope safepoint_scope(isolate(), SafepointKind::kIsolate);
+  DisallowGarbageCollection no_gc;
+  RwxMemoryWriteScope scope("For updating clone");
+
+  VirtualMemoryCage* cloned_trusted_cage_base =
+      isolate()->isolate_group()->GetTrustedPtrComprCage();
+  code_space_->RebaseFullPointers(original_trusted_cage,
+                                  cloned_trusted_cage_base);
+}
+
+#endif  // V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
 
 void Heap::InitializeHashSeed() {
   DCHECK(!deserialization_complete_);

--- a/src/heap/heap.h
+++ b/src/heap/heap.h
@@ -738,6 +738,9 @@ class Heap final {
   // Sets up the heap memory without creating any objects
   // as an clone of the original heap.
   void SetUpSpacesClone(Heap* original);
+
+  void RebaseAbsolutePointersToTrustedCage(
+      VirtualMemoryCage* original_trusted_cage);
 #endif
 
   // Prepares the heap, setting up for deserialization.

--- a/src/heap/paged-spaces.cc
+++ b/src/heap/paged-spaces.cc
@@ -36,6 +36,11 @@
 #include "src/objects/string.h"
 #include "src/utils/utils.h"
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+#include "src/codegen/assembler-inl.h"
+#include "src/objects/objects-inl.h"
+#endif
+
 namespace v8 {
 namespace internal {
 
@@ -151,7 +156,39 @@ PagedSpaceBase::PagedSpaceBase(Heap* heap, PagedSpaceBase* original_space,
                                     cloned_cage));
   }
 }
-#endif
+
+void CodeSpace::RebaseFullPointers(VirtualMemoryCage* original_cage,
+                                   VirtualMemoryCage* new_cage) {
+  PtrComprCageBase cage_base = GetPtrComprCageBase();
+  PagedSpaceObjectIterator obj_it(heap_, this);
+  for (Tagged<HeapObject> obj = obj_it.Next(); !obj.is_null();
+       obj = obj_it.Next()) {
+    if (!IsInstructionStream(obj, cage_base)) continue;
+    Tagged<InstructionStream> istream = TrustedCast<InstructionStream>(obj);
+    Tagged<Code> code;
+    if (!istream->TryGetCode(&code, kAcquireLoad)) continue;
+
+    WritableJitAllocation jit_allocation = ThreadIsolation::LookupJitAllocation(
+        istream.address(), istream->Size(),
+        ThreadIsolation::JitAllocationType::kInstructionStream, true);
+    WritableRelocIterator reloc_it(
+        jit_allocation, code->instruction_stream(), code->constant_pool(),
+        RelocInfo::ModeMask(RelocInfo::FULL_EMBEDDED_OBJECT));
+    for (; !reloc_it.done(); reloc_it.next()) {
+      Tagged<HeapObject> original_target =
+          reloc_it.rinfo()->target_object(heap()->isolate());
+      if (original_cage->Contains(original_target->address())) {
+        Address rebased_address =
+            original_cage->Rebase(original_target->address(), new_cage);
+        reloc_it.rinfo()->set_target_object(
+            HeapObject::FromAddress(rebased_address),
+            ICacheFlushMode::SKIP_ICACHE_FLUSH);
+      }
+    }
+    code->FlushICache();
+  }
+}
+#endif  // V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
 
 PageMetadata* PagedSpaceBase::InitializePage(
     MutablePageMetadata* mutable_page_metadata) {

--- a/src/heap/paged-spaces.h
+++ b/src/heap/paged-spaces.h
@@ -539,6 +539,9 @@ class CodeSpace final : public PagedSpace {
   CodeSpace(Heap* heap, CodeSpace* original)
       : PagedSpace(heap, original, CODE_SPACE, EXECUTABLE,
                    FreeList::CreateFreeList(), CompactionSpaceKind::kNone) {}
+
+  void RebaseFullPointers(VirtualMemoryCage* original_cage,
+                          VirtualMemoryCage* new_cage);
 #endif
 };
 

--- a/src/maglev/maglev-assembler-inl.h
+++ b/src/maglev/maglev-assembler-inl.h
@@ -730,7 +730,13 @@ void MoveArgumentsForBuiltin(MaglevAssembler* masm, Args&&... args) {
         DCHECK_EQ(target, arg.location()->AssignedGeneralRegister());
         USE(target);
       } else {
-        masm->Move(target, std::forward<Arg>(arg));
+        if constexpr (std::is_convertible_v<std::decay_t<Arg>,
+                                            Handle<HeapObject>>) {
+          masm->MoveTagged(target, std::forward<Arg>(arg));
+          masm->DecompressTagged(target, target);
+        } else {
+          masm->Move(target, std::forward<Arg>(arg));
+        }
       }
 #ifdef DEBUG
       written_registers.set(target);
@@ -756,7 +762,9 @@ void MoveArgumentsForBuiltin(MaglevAssembler* masm, Args&&... args) {
       // TODO(leszeks): Include the context register in the parallel moves
       // described above.
       static_assert(!std::is_same_v<Register, std::decay_t<decltype(context)>>);
-      masm->Move(Descriptor::ContextRegister(), context);
+      masm->MoveTagged(Descriptor::ContextRegister(), context);
+      masm->DecompressTagged(Descriptor::ContextRegister(),
+                             Descriptor::ContextRegister());
     }
   }
 }

--- a/src/maglev/maglev-assembler.cc
+++ b/src/maglev/maglev-assembler.cc
@@ -680,7 +680,7 @@ void MaglevAssembler::TryMigrateInstance(Register object,
     SaveRegisterStateForCall save_register_state(this, register_snapshot);
 
     Push(object);
-    Move(kContextRegister, native_context().object());
+    LoadNativeContextInPinnedRegister();
     CallRuntime(Runtime::kTryMigrateInstance);
     save_register_state.DefineSafepoint();
 

--- a/src/maglev/maglev-assembler.h
+++ b/src/maglev/maglev-assembler.h
@@ -461,6 +461,7 @@ class V8_EXPORT_PRIVATE MaglevAssembler : public MacroAssembler {
   void Move(ExternalReference dst, int32_t imm);
 
   inline void MoveTagged(Register dst, Handle<HeapObject> obj);
+  inline void LoadNativeContextInPinnedRegister();
 
   inline void LoadMapForCompare(Register dst, Register obj);
 

--- a/src/maglev/maglev-ir.cc
+++ b/src/maglev/maglev-ir.cc
@@ -1086,7 +1086,8 @@ void Float64Constant::DoLoadToRegister(MaglevAssembler* masm,
 }
 
 void Constant::DoLoadToRegister(MaglevAssembler* masm, Register reg) const {
-  __ Move(reg, object_.object());
+  __ MoveTagged(reg, object_.object());
+  __ DecompressTagged(reg, reg);
 }
 
 void RootConstant::DoLoadToRegister(MaglevAssembler* masm, Register reg) const {
@@ -4022,8 +4023,10 @@ void ConvertReceiver::GenerateCode(MaglevAssembler* masm,
         v8_flags.debug_code ? Label::Distance::kFar : Label::Distance::kNear);
     __ bind(&convert_global_proxy);
     // Patch receiver to global proxy.
-    __ Move(ToRegister(result()),
-            native_context_.global_proxy_object(broker).object());
+    auto dst_register = ToRegister(result());
+    __ MoveTagged(dst_register,
+                  native_context_.global_proxy_object(broker).object());
+    __ DecompressTagged(dst_register, dst_register);
     __ Jump(&done);
   }
 
@@ -4063,7 +4066,7 @@ void CheckDerivedConstructResult::GenerateCode(MaglevAssembler* masm,
   __ bind(&do_throw);
   __ Jump(__ MakeDeferredCode(
       [](MaglevAssembler* masm, CheckDerivedConstructResult* node) {
-        __ Move(kContextRegister, masm->native_context().object());
+        __ LoadNativeContextInPinnedRegister();
         __ CallRuntime(Runtime::kThrowConstructorReturnedNonObject);
         masm->DefineExceptionHandlerAndLazyDeoptPoint(node);
         __ Abort(AbortReason::kUnexpectedReturnFromThrow);
@@ -4377,7 +4380,7 @@ void HasInPrototypeChain::GenerateCode(MaglevAssembler* masm,
             snapshot.live_registers.clear(result_reg);
             SaveRegisterStateForCall save_register_state(masm, snapshot);
             __ Push(object_reg, node->prototype().object());
-            __ Move(kContextRegister, masm->native_context().object());
+            __ LoadNativeContextInPinnedRegister();
             __ CallRuntime(Runtime::kHasInPrototypeChain, 2);
             masm->DefineExceptionHandlerPoint(node);
             save_register_state.DefineSafepointWithLazyDeopt(
@@ -5828,7 +5831,7 @@ void ThrowReferenceErrorIfHole::GenerateCode(MaglevAssembler* masm,
       __ IsRootConstant(value(), RootIndex::kTheHoleValue),
       [](MaglevAssembler* masm, ThrowReferenceErrorIfHole* node) {
         __ Push(node->name().object());
-        __ Move(kContextRegister, masm->native_context().object());
+        __ LoadNativeContextInPinnedRegister();
         __ CallRuntime(Runtime::kThrowAccessedUninitializedVariable, 1);
         masm->DefineExceptionHandlerAndLazyDeoptPoint(node);
         __ Abort(AbortReason::kUnexpectedReturnFromThrow);
@@ -5850,7 +5853,7 @@ void ThrowSuperNotCalledIfHole::GenerateCode(MaglevAssembler* masm,
   __ JumpToDeferredIf(
       __ IsRootConstant(value(), RootIndex::kTheHoleValue),
       [](MaglevAssembler* masm, ThrowSuperNotCalledIfHole* node) {
-        __ Move(kContextRegister, masm->native_context().object());
+        __ LoadNativeContextInPinnedRegister();
         __ CallRuntime(Runtime::kThrowSuperNotCalled, 0);
         masm->DefineExceptionHandlerAndLazyDeoptPoint(node);
         __ Abort(AbortReason::kUnexpectedReturnFromThrow);
@@ -5872,7 +5875,7 @@ void ThrowSuperAlreadyCalledIfNotHole::GenerateCode(
   __ JumpToDeferredIf(
       NegateCondition(__ IsRootConstant(value(), RootIndex::kTheHoleValue)),
       [](MaglevAssembler* masm, ThrowSuperAlreadyCalledIfNotHole* node) {
-        __ Move(kContextRegister, masm->native_context().object());
+        __ LoadNativeContextInPinnedRegister();
         __ CallRuntime(Runtime::kThrowSuperAlreadyCalledError, 0);
         masm->DefineExceptionHandlerAndLazyDeoptPoint(node);
         __ Abort(AbortReason::kUnexpectedReturnFromThrow);
@@ -5890,7 +5893,7 @@ void ThrowIfNotCallable::GenerateCode(MaglevAssembler* masm,
   Label* if_not_callable = __ MakeDeferredCode(
       [](MaglevAssembler* masm, ThrowIfNotCallable* node) {
         __ Push(node->value());
-        __ Move(kContextRegister, masm->native_context().object());
+        __ LoadNativeContextInPinnedRegister();
         __ CallRuntime(Runtime::kThrowCalledNonCallable, 1);
         masm->DefineExceptionHandlerAndLazyDeoptPoint(node);
         __ Abort(AbortReason::kUnexpectedReturnFromThrow);
@@ -5923,7 +5926,7 @@ void ThrowIfNotSuperConstructor::GenerateCode(MaglevAssembler* masm,
           [](MaglevAssembler* masm, ThrowIfNotSuperConstructor* node) {
             __ Push(ToRegister(node->constructor()),
                     ToRegister(node->function()));
-            __ Move(kContextRegister, masm->native_context().object());
+            __ LoadNativeContextInPinnedRegister();
             __ CallRuntime(Runtime::kThrowNotSuperConstructor, 2);
             masm->DefineExceptionHandlerAndLazyDeoptPoint(node);
             __ Abort(AbortReason::kUnexpectedReturnFromThrow);
@@ -6902,7 +6905,7 @@ void GenerateTransitionElementsKind(
               } else {
                 SaveRegisterStateForCall save_state(masm, register_snapshot);
                 __ Push(object, transition_target.object());
-                __ Move(kContextRegister, masm->native_context().object());
+                __ LoadNativeContextInPinnedRegister();
                 __ CallRuntime(Runtime::kTransitionElementsKind);
                 save_state.DefineSafepoint();
               }
@@ -7325,7 +7328,7 @@ void AttemptOnStackReplacement(MaglevAssembler* masm,
       SaveRegisterStateForCall save_register_state(masm, snapshot);
       DCHECK(!node->unit()->is_inline());
       __ Push(Smi::FromInt(osr_offset.ToInt()));
-      __ Move(kContextRegister, masm->native_context().object());
+      __ LoadNativeContextInPinnedRegister();
       __ CallRuntime(Runtime::kCompileOptimizedOSRFromMaglev, 1);
       save_register_state.DefineSafepoint();
       __ Move(maybe_target_code, kReturnRegister0);
@@ -7372,7 +7375,8 @@ void TryOnStackReplacement::GenerateCode(MaglevAssembler* masm,
   Register scratch1 = temps.Acquire();
 
   const Register osr_state = scratch1;
-  __ Move(scratch0, unit_->feedback().object());
+  __ MoveTagged(scratch0, unit_->feedback().object());
+  __ DecompressTagged(scratch0, scratch0);
   __ AssertFeedbackVector(scratch0, scratch1);
   __ LoadByte(osr_state,
               FieldMemOperand(scratch0, FeedbackVector::kOsrStateOffset));
@@ -7745,7 +7749,7 @@ void HandleNoHeapWritesInterrupt::GenerateCode(MaglevAssembler* masm,
         {
           SaveRegisterStateForCall save_register_state(
               masm, node->register_snapshot());
-          __ Move(kContextRegister, masm->native_context().object());
+          __ LoadNativeContextInPinnedRegister();
           __ CallRuntime(Runtime::kHandleNoHeapWritesInterrupts, 0);
           save_register_state.DefineSafepointWithLazyDeopt(
               node->lazy_deopt_info());

--- a/src/maglev/x64/maglev-assembler-x64-inl.h
+++ b/src/maglev/x64/maglev-assembler-x64-inl.h
@@ -654,6 +654,16 @@ void MaglevAssembler::MoveTagged(Register dst, Handle<HeapObject> obj) {
 #endif
 }
 
+void MaglevAssembler::LoadNativeContextInPinnedRegister() {
+#ifdef V8_COMPRESS_POINTERS
+  MacroAssembler::Move(kContextRegister, native_context().object(),
+                       RelocInfo::COMPRESSED_EMBEDDED_OBJECT);
+  DecompressTagged(kContextRegister, kContextRegister);
+#else
+  MacroAssembler::Move(kContextRegister, masm->native_context().object());
+#endif
+}
+
 inline void MaglevAssembler::Move(Register dst, intptr_t p) {
   MacroAssembler::Move(dst, p);
 }

--- a/src/maglev/x64/maglev-assembler-x64.cc
+++ b/src/maglev/x64/maglev-assembler-x64.cc
@@ -175,7 +175,7 @@ void MaglevAssembler::StringCharCodeOrCodePointAt(
           __ Push(string);
           __ SmiTag(index);
           __ Push(index);
-          __ Move(kContextRegister, masm->native_context().object());
+          __ LoadNativeContextInPinnedRegister();
           // This call does not throw nor can deopt.
           if (mode ==
               BuiltinStringPrototypeCharCodeOrCodePointAt::kCodePointAt) {

--- a/src/maglev/x64/maglev-ir-x64.cc
+++ b/src/maglev/x64/maglev-ir-x64.cc
@@ -1089,7 +1089,7 @@ void HandleInterruptsAndTiering(MaglevAssembler* masm, ZoneLabelRef done,
     {
       SaveRegisterStateForCall save_register_state(masm,
                                                    node->register_snapshot());
-      __ Move(kContextRegister, masm->native_context().object());
+      __ LoadNativeContextInPinnedRegister();
       __ Push(MemOperand(rbp, StandardFrameConstants::kFunctionOffset));
       __ CallRuntime(Runtime::kBytecodeBudgetInterruptWithStackCheck_Maglev, 1);
       save_register_state.DefineSafepointWithLazyDeopt(node->lazy_deopt_info());
@@ -1103,7 +1103,7 @@ void HandleInterruptsAndTiering(MaglevAssembler* masm, ZoneLabelRef done,
   {
     SaveRegisterStateForCall save_register_state(masm,
                                                  node->register_snapshot());
-    __ Move(kContextRegister, masm->native_context().object());
+    __ LoadNativeContextInPinnedRegister();
     __ Push(MemOperand(rbp, StandardFrameConstants::kFunctionOffset));
     // Note: must not cause a lazy deopt!
     __ CallRuntime(Runtime::kBytecodeBudgetInterrupt_Maglev, 1);


### PR DESCRIPTION
Switch from embedded absolute pointers in code objects to relative compressed offsets.

We plan to share code within the code cage across two (or more) isolate groups. To achieve this, we must ensure that code objects do not embed absolute addresses into a pointer cage. For example, a code object might embed an absolute address of a context object that resides in a pointer cage. In a cloned isolate, the GC cannot safely traverse such code objects because an absolute pointer would escape to the other isolate group’s pointer cage.

There are two classes of embedded pointers in code objects: pointers into the pointer cage and pointers into the trusted cage. 
For pointers into the pointer cage, we replace absolute addresses with compressed relative offsets so the GC reaches the cloned pointer cage rather than the original one.
For pointers into the trusted cage, we enumerate them at clone time and rewrite them manually, since decompressing them inside generated code is non-trivial.