### PR TITLE
Part 6: Introduce external pointers table cloning

### DIFF
--- a/src/common/segmented-table-inl.h
+++ b/src/common/segmented-table-inl.h
@@ -132,6 +132,28 @@ void SegmentedTable<Entry, size>::TearDown() {
   vas_ = nullptr;
 }
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+template <typename Entry, size_t size>
+void SegmentedTable<Entry, size>::EnsureNewSegment(uint32_t offset) {
+  DCHECK(is_initialized());
+  base::MutexGuard guard(*segment_pool_grow_mutex_);
+  Address hint =
+      reinterpret_cast<Address>(reinterpret_cast<char*>(base()) + offset);
+
+  // Check segment pool first.
+  for (int i = 0; i < static_cast<int>(kSegmentPoolSize); ++i) {
+    if (offset == segment_pool_[i].load()) {
+      CHECK(segment_pool_[i].compare_exchange_strong(offset,
+                                                     kSegmentPoolFreeEntry));
+      return;
+    }
+  }
+  auto start = vas_->AllocatePages(hint, kSegmentSize, kSegmentSize,
+                                   PagePermissions::kReadWrite);
+  CHECK_EQ(start, hint);
+}
+#endif
+
 template <typename Entry, size_t size>
 typename SegmentedTable<Entry, size>::FreelistHead
 SegmentedTable<Entry, size>::InitializeFreeList(Segment segment,

--- a/src/common/segmented-table.h
+++ b/src/common/segmented-table.h
@@ -236,6 +236,11 @@ class V8_EXPORT_PRIVATE SegmentedTable {
   // Deallocates all memory associated with this table.
   void TearDown();
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  // Allocate new empty segment with the specified offset.
+  void EnsureNewSegment(uint32_t offset);
+#endif
+
   // The pointer to the base of the virtual address space backing this table.
   // All entry accesses happen through this pointer.
   // It is equivalent to |vas_->base()| and is effectively const after

--- a/src/heap/read-only-heap.cc
+++ b/src/heap/read-only-heap.cc
@@ -159,6 +159,24 @@ void ReadOnlyHeap::SetUpClone(Isolate* clone_isolate,
     DCHECK_EQ(original_ro_space->accounting_stats_.Size(),
               cloned_ro_space->accounting_stats_.Size());
 #endif
+    cloned_group->code_pointer_table()->CloneSpaceFrom(
+        original_group->code_pointer_table(),
+        original_group->read_only_artifacts()
+            ->read_only_heap()
+            ->code_pointer_space(),
+        new_ro_artifacts->read_only_heap()->code_pointer_space(),
+        [original_code_cage =
+             original_group->GetCodeRange()](Address original_entrypoint) {
+          // For read only part of code pointer table all entrypoint are c++
+          // functions.
+          DCHECK(!original_code_cage->Contains(original_entrypoint));
+          return original_entrypoint;
+        },
+        [original_cage = original_group->GetPtrComprCage(),
+         cloned_cage =
+             cloned_group->GetPtrComprCage()](Address original_code_object) {
+          return original_cage->Rebase(original_code_object, cloned_cage);
+        });
   } else {
     ReadOnlyArtifacts* artifacts = cloned_group->read_only_artifacts();
     DCHECK_NOT_NULL(artifacts);

--- a/src/sandbox/code-pointer-table-inl.h
+++ b/src/sandbox/code-pointer-table-inl.h
@@ -98,6 +98,22 @@ bool CodePointerTableEntry::IsMarked() const {
   return value & kMarkingBit;
 }
 
+template <typename EntrypointMappingFunction,
+          typename CodeObjectMappingFunction>
+void CodePointerTableEntry::Remap(const CodePointerTableEntry& original,
+                                  EntrypointMappingFunction entrypoint_mapping,
+                                  CodeObjectMappingFunction code_mapping) {
+  CFIMetadataWriteScope write_scope("CodePointerTable write");
+  const Address original_code_object = original.code_.load();
+  const CodeEntrypointTag tag = base::bit_cast<CodeEntrypointTag>(
+      original.entrypoint_.load() & kFreeCodePointerTableEntryTag);
+  const Address original_entrypoint = original.GetEntrypoint(tag);
+  const Address remapped_code_object = code_mapping(original_code_object);
+  const Address remapped_entrypoint = entrypoint_mapping(original_entrypoint);
+  MakeCodePointerEntry(remapped_code_object, remapped_entrypoint, tag,
+                       original.IsMarked());
+}
+
 Address CodePointerTable::GetEntrypoint(CodePointerHandle handle,
                                         CodeEntrypointTag tag) const {
   uint32_t index = HandleToIndex(handle);
@@ -170,6 +186,24 @@ CodePointerHandle CodePointerTable::IndexToHandle(uint32_t index) const {
   CodePointerHandle handle = index << kCodePointerHandleShift;
   DCHECK_EQ(index, handle >> kCodePointerHandleShift);
   return handle | kCodePointerHandleMarker;
+}
+
+template <typename EntrypointMappingFunction,
+          typename CodeObjectMappingFunction>
+void CodePointerTable::CloneSpaceFrom(
+    CodePointerTable* original, Space* original_space, Space* destination_space,
+    EntrypointMappingFunction entrypoint_mapping,
+    CodeObjectMappingFunction code_mapping) {
+  CloneSegmentsData(original, original_space, destination_space);
+  original->IterateEntriesIn(
+      original_space,
+      [this, original, entrypoint_mapping, code_mapping](uint32_t index) {
+        const CodePointerTableEntry& original_entry = original->at(index);
+        if (original_entry.IsFreelistEntry()) {
+          return;
+        }
+        at(index).Remap(original_entry, entrypoint_mapping, code_mapping);
+      });
 }
 
 }  // namespace internal

--- a/src/sandbox/code-pointer-table.h
+++ b/src/sandbox/code-pointer-table.h
@@ -77,6 +77,12 @@ struct CodePointerTableEntry {
  private:
   friend class CodePointerTable;
 
+  template <typename EntrypointMappingFunction,
+            typename CodeObjectMappingFunction>
+  void Remap(const CodePointerTableEntry& original,
+             EntrypointMappingFunction entrypoint_mapping,
+             CodeObjectMappingFunction code_mapping);
+
   // Freelist entries contain the index of the next free entry in their lower 32
   // bits and are tagged with the kFreeCodePointerTableEntryTag.
   static constexpr Address kFreeEntryTag = kFreeCodePointerTableEntryTag;
@@ -182,6 +188,13 @@ class V8_EXPORT_PRIVATE CodePointerTable
   // receive the handle and content (Code object pointer) of that entry.
   template <typename Callback>
   void IterateActiveEntriesIn(Space* space, Callback callback);
+
+  template <typename EntrypointMappingFunction,
+            typename CodeObjectMappingFunction>
+  void CloneSpaceFrom(CodePointerTable* original, Space* original_space,
+                      Space* destination_space,
+                      EntrypointMappingFunction entrypoint_mapping,
+                      CodeObjectMappingFunction code_mapping);
 
   // The base address of this table, for use in JIT compilers.
   Address base_address() const { return base(); }

--- a/src/sandbox/external-entity-table-inl.h
+++ b/src/sandbox/external-entity-table-inl.h
@@ -8,6 +8,10 @@
 #include "src/sandbox/external-entity-table.h"
 // Include the non-inl header before the rest of the headers.
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+#include <algorithm>
+#endif
+
 #include "src/base/atomicops.h"
 #include "src/base/emulated-virtual-address-subspace.h"
 #include "src/base/iterator.h"
@@ -419,6 +423,33 @@ void ExternalEntityTable<Entry, size>::IterateEntriesIn(Space* space,
     }
   }
 }
+
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+template <typename Entry, size_t size>
+void ExternalEntityTable<Entry, size>::CloneSegmentsData(
+    ExternalEntityTable<Entry, size>* original_table, Space* original_space,
+    Space* target_space) {
+  DCHECK(target_space->BelongsTo(this));
+
+  base::MutexGuard source_guard(&original_space->mutex_);
+  base::MutexGuard destination_guard(&target_space->mutex_);
+  for (auto original_segment : original_space->segments_) {
+    Address original_segment_address =
+        original_table->base() + original_segment.offset();
+    Address target_segment_address = this->base() + original_segment.offset();
+    this->EnsureNewSegment(original_segment.offset());
+    std::copy(reinterpret_cast<char*>(original_segment_address),
+              reinterpret_cast<char*>(original_segment_address + kSegmentSize),
+              reinterpret_cast<char*>(target_segment_address));
+    auto result_pair =
+        target_space->segments_.insert(Segment(original_segment.number()));
+    DCHECK(result_pair.second);  // Check that we inserted a new element.
+    DCHECK_EQ(result_pair.first->offset(), original_segment.offset());
+    USE(result_pair);
+  }
+  target_space->freelist_head_.store(original_space->freelist_head_.load());
+}
+#endif
 
 }  // namespace internal
 }  // namespace v8

--- a/src/sandbox/external-entity-table.h
+++ b/src/sandbox/external-entity-table.h
@@ -213,6 +213,11 @@ class V8_EXPORT_PRIVATE ExternalEntityTable
   template <typename Callback>
   void IterateEntriesIn(Space* space, Callback callback);
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  void CloneSegmentsData(ExternalEntityTable<Entry, size>* original_table,
+                         Space* original_space, Space* target_space);
+#endif
+
   // Marker value for the freelist_head_ member to indicate that entry
   // allocation is currently forbidden, for example because the table is being
   // swept as part of a mark+sweep garbage collection. This value should never

--- a/src/sandbox/external-pointer-table-inl.h
+++ b/src/sandbox/external-pointer-table-inl.h
@@ -125,6 +125,10 @@ void ExternalPointerTableEntry::Mark() {
   USE(success);
 }
 
+bool ExternalPointerTableEntry::IsMarked() const {
+  return payload_.load().HasMarkBitSet();
+}
+
 void ExternalPointerTableEntry::MakeEvacuationEntry(Address handle_location) {
   Payload new_payload(handle_location, kExternalPointerEvacuationEntryTag);
   payload_.store(new_payload, std::memory_order_relaxed);
@@ -169,6 +173,15 @@ void ExternalPointerTableEntry::CopyFrom(const ExternalPointerTableEntry& src) {
 #if defined(LEAK_SANITIZER)
   raw_pointer_for_lsan_ = src.raw_pointer_for_lsan_;
 #endif  // LEAK_SANITIZER
+}
+
+template <typename MappingFunction>
+void ExternalPointerTableEntry::Remap(const ExternalPointerTableEntry& original,
+                                      MappingFunction mapping) {
+  const ExternalPointerTag tag = original.GetExternalPointerTag();
+  const Address original_pointer = original.GetExternalPointer(tag);
+  const Address remapped_pointer = mapping(original_pointer);
+  MakeExternalPointerEntry(remapped_pointer, tag, original.IsMarked());
 }
 
 Address ExternalPointerTable::Get(ExternalPointerHandle handle,
@@ -404,6 +417,22 @@ void ExternalPointerTable::FreeManagedResourceIfPresent(uint32_t entry_index) {
                    resource->ept_entry_ == IndexToHandle(entry_index));
     resource->ept_entry_ = kNullExternalPointerHandle;
   }
+}
+
+template <typename MappingFunction>
+void ExternalPointerTable::CloneSpaceFrom(ExternalPointerTable* original,
+                                          Space* original_space,
+                                          Space* destination_space,
+                                          MappingFunction mapping) {
+  CloneSegmentsData(original, original_space, destination_space);
+  original->IterateEntriesIn(
+      original_space, [this, original, mapping](uint32_t index) {
+        const ExternalPointerTableEntry& original_entry = original->at(index);
+        if (!original_entry.payload_.load().ContainsPointer()) {
+          return;
+        }
+        at(index).Remap(original_entry, mapping);
+      });
 }
 
 }  // namespace internal

--- a/src/sandbox/external-pointer-table.h
+++ b/src/sandbox/external-pointer-table.h
@@ -105,6 +105,9 @@ struct ExternalPointerTableEntry {
   // Mark this entry as alive during table garbage collection.
   inline void Mark();
 
+  // Test whether this entry is currently marked as alive.
+  inline bool IsMarked() const;
+
   static constexpr bool IsWriteProtected = false;
 
  private:
@@ -198,6 +201,10 @@ struct ExternalPointerTableEntry {
    private:
     Address encoded_word_;
   };
+
+  template <typename MappingFunction>
+  void Remap(const ExternalPointerTableEntry& original,
+             MappingFunction mapping);
 
   inline Payload GetRawPayload() {
     return payload_.load(std::memory_order_relaxed);
@@ -349,6 +356,10 @@ class V8_EXPORT_PRIVATE ExternalPointerTable
     // Not atomic.  Mutators and concurrent marking must be paused.
     void AssertEmpty() { CHECK(segments_.empty()); }
   };
+
+  template <typename MappingFunction>
+  void CloneSpaceFrom(ExternalPointerTable* original, Space* original_space,
+                      Space* destination_space, MappingFunction mapping);
 
   // Initializes all slots in the RO space from pre-existing artifacts.
   void SetUpFromReadOnlyArtifacts(Space* read_only_space,

--- a/src/sandbox/js-dispatch-table-inl.h
+++ b/src/sandbox/js-dispatch-table-inl.h
@@ -372,6 +372,42 @@ bool JSDispatchTable::IsCompatibleCode(Tagged<Code> code,
 }
 // LINT.ThenChange(/src/builtins/builtins-inl.h:IsCompatibleJSBuiltin)
 
+template <typename EntrypointMappingFunction,
+          typename CodeObjectMappingFunction>
+void JSDispatchTable::CloneSpaceFrom(
+    JSDispatchTable* original, Space* original_space, Space* destination_space,
+    EntrypointMappingFunction entrypoint_mapping,
+    CodeObjectMappingFunction code_mapping) {
+  CloneSegmentsData(original, original_space, destination_space);
+  original->IterateEntriesIn(
+      original_space,
+      [this, original, entrypoint_mapping, code_mapping](uint32_t index) {
+        const JSDispatchEntry& original_entry = original->at(index);
+        if (original_entry.IsFreelistEntry()) {
+          return;
+        }
+        at(index).Remap(original_entry, entrypoint_mapping, code_mapping);
+      });
+}
+
+template <typename EntrypointMappingFunction,
+          typename CodeObjectMappingFunction>
+void JSDispatchEntry::Remap(const JSDispatchEntry& original,
+                            EntrypointMappingFunction entrypoint_mapping,
+                            CodeObjectMappingFunction code_mapping) {
+  CFIMetadataWriteScope write_scope("JSDispatchTable write");
+  const Address original_entrypoint = original.GetEntrypoint();
+  const Address original_code_pointer = original.GetCodePointer();
+  DCHECK(Internals::HasHeapObjectTag(original_code_pointer));
+  const Address original_code_pointer_untagged =
+      original_code_pointer - kHeapObjectTag;
+  const Address remapped_code_pointer =
+      code_mapping(original_code_pointer_untagged);
+  const Address remapped_entrypoint = entrypoint_mapping(original_entrypoint);
+  MakeJSDispatchEntry(remapped_code_pointer, remapped_entrypoint,
+                      original.GetParameterCount(), original.IsMarked());
+}
+
 }  // namespace internal
 }  // namespace v8
 

--- a/src/sandbox/js-dispatch-table.h
+++ b/src/sandbox/js-dispatch-table.h
@@ -115,6 +115,12 @@ struct JSDispatchEntry {
  private:
   friend class JSDispatchTable;
 
+  template <typename EntrypointMappingFunction,
+            typename CodeObjectMappingFunction>
+  void Remap(const JSDispatchEntry& original,
+             EntrypointMappingFunction entrypoint_mapping,
+             CodeObjectMappingFunction code_mapping);
+
   // The first word contains the pointer to the (executable) entrypoint.
   std::atomic<Address> entrypoint_;
 
@@ -280,6 +286,13 @@ class V8_EXPORT_PRIVATE JSDispatchTable
   // Returns the number of live entries after sweeping.
   template <typename Callback>
   uint32_t Sweep(Space* space, Counters* counters, Callback callback);
+
+  template <typename EntrypointMappingFunction,
+            typename CodeObjectMappingFunction>
+  void CloneSpaceFrom(JSDispatchTable* original, Space* original_space,
+                      Space* destination_space,
+                      EntrypointMappingFunction entrypoint_mapping,
+                      CodeObjectMappingFunction code_mapping);
 
   // Iterate over all active entries in the given space.
   //

--- a/src/sandbox/trusted-pointer-table-inl.h
+++ b/src/sandbox/trusted-pointer-table-inl.h
@@ -108,6 +108,16 @@ bool TrustedPointerTableEntry::IsMarked() const {
   return payload_.load(std::memory_order_relaxed).HasMarkBitSet();
 }
 
+template <typename TrustedMappingFunction>
+void TrustedPointerTableEntry::Remap(const TrustedPointerTableEntry& original,
+                                     TrustedMappingFunction mapping) {
+  const Payload original_payload = original.payload_.load();
+  const IndirectPointerTag tag = original_payload.ExtractTag();
+  const Address original_pointer = original.GetPointer(tag);
+  const Address remapped_pointer = mapping(original_pointer);
+  MakeTrustedPointerEntry(remapped_pointer, tag, original.IsMarked());
+}
+
 bool TrustedPointerTable::IsUnpublished(TrustedPointerHandle handle) const {
   uint32_t index = HandleToIndex(handle);
   return at(index).HasPointer(kUnpublishedIndirectPointerTag);
@@ -196,6 +206,21 @@ void TrustedPointerTable::IterateActiveEntriesIn(Space* space,
       callback(IndexToHandle(index), pointer);
     }
   });
+}
+
+template <typename TrustedObjectMappingFunction>
+void TrustedPointerTable::CloneSpaceFrom(
+    TrustedPointerTable* original, Space* original_space,
+    Space* destination_space, TrustedObjectMappingFunction trusted_mapping) {
+  CloneSegmentsData(original, original_space, destination_space);
+  original->IterateEntriesIn(
+      original_space, [this, original, trusted_mapping](uint32_t index) {
+        const TrustedPointerTableEntry& original_entry = original->at(index);
+        if (original_entry.IsFreelistEntry()) {
+          return;
+        }
+        at(index).Remap(original_entry, trusted_mapping);
+      });
 }
 
 uint32_t TrustedPointerTable::HandleToIndex(TrustedPointerHandle handle) const {

--- a/src/sandbox/trusted-pointer-table.h
+++ b/src/sandbox/trusted-pointer-table.h
@@ -73,6 +73,10 @@ struct TrustedPointerTableEntry {
   // Test whether this entry is currently marked as alive.
   inline bool IsMarked() const;
 
+  template <typename TrustedMappingFunction>
+  void Remap(const TrustedPointerTableEntry& original,
+             TrustedMappingFunction mapping);
+
   static constexpr bool IsWriteProtected = false;
 
  private:
@@ -197,6 +201,11 @@ class V8_EXPORT_PRIVATE TrustedPointerTable
   // receive the handle and content of that entry.
   template <typename Callback>
   void IterateActiveEntriesIn(Space* space, Callback callback);
+
+  template <typename TrustedObjectMappingFunction>
+  void CloneSpaceFrom(TrustedPointerTable* original, Space* original_space,
+                      Space* destination_space,
+                      TrustedObjectMappingFunction trusted_mapping);
 
   // The base address of this table, for use in JIT compilers.
   Address base_address() const { return base(); }


### PR DESCRIPTION
To finalize the cloned isolate and isolate group, we need to recreate all [external pointer tables](https://docs.google.com/document/d/1V3sxltuFjjhp_6grGHgfqZNK57qfzGzme0QTk0IXDHk/). 

Since these tables will be populated with values specific to the cloned isolate/group, we copy each table while preserving the original indexing, then rebase the pointers onto the corresponding cages in the clone.