### PR TITLE
Part 7: Introduce cloning API

### DIFF
--- a/include/v8-isolate.h
+++ b/include/v8-isolate.h
@@ -270,7 +270,11 @@ class V8_EXPORT IsolateGroup {
   V8_INLINE bool SandboxContains(void* pointer) const { return true; }
 #endif
 
+  void Freeze();
+
   IsolateGroup Clone();
+
+  void SetReadOnlyPermissionForSandbox();
 
  private:
   friend class Isolate;

--- a/include/v8-isolate.h
+++ b/include/v8-isolate.h
@@ -270,6 +270,8 @@ class V8_EXPORT IsolateGroup {
   V8_INLINE bool SandboxContains(void* pointer) const { return true; }
 #endif
 
+  IsolateGroup Clone();
+
  private:
   friend class Isolate;
   friend class ArrayBuffer::Allocator;

--- a/include/v8-isolate.h
+++ b/include/v8-isolate.h
@@ -1878,6 +1878,23 @@ class V8_EXPORT Isolate {
    */
   uint64_t GetHashSeed();
 
+  /**
+   * Materialize an already in-memory–cloned isolate.
+   *
+   * After cloning an isolate group, the heap memory of all isolates in the
+   * original group is cloned as well. However, to use a cloned isolate, you
+   * must first materialize it.
+   *
+   * Materialization constructs all metadata and the isolate’s internal
+   * structures without re-allocating/writing its memory.
+   *
+   * Supported only in a multi-sandbox configuration with pointer compression
+   * enabled.
+   *
+   */
+  static Isolate* MaterializeClone(Isolate* original,
+                                   const IsolateGroup& cloned_group);
+
   Isolate() = delete;
   ~Isolate() = delete;
   Isolate(const Isolate&) = delete;

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -9991,6 +9991,88 @@ Isolate* Isolate::New(const Isolate::CreateParams& params) {
   return Isolate::New(IsolateGroup::GetDefault(), params);
 }
 
+Isolate* Isolate::MaterializeClone(Isolate* original,
+                                   const IsolateGroup& cloned_group) {
+  Isolate* cloned_isolate = Allocate(cloned_group);
+  Isolate::CreateParams params;
+  params.array_buffer_allocator =
+      ArrayBuffer::Allocator::NewDefaultAllocator(cloned_group);
+
+  i::Isolate* i_isolate = reinterpret_cast<i::Isolate*>(cloned_isolate);
+  TRACE_EVENT_CALL_STATS_SCOPED(i_isolate, "v8", "V8.IsolateInitialize");
+  if (auto allocator = params.array_buffer_allocator_shared) {
+    CHECK(params.array_buffer_allocator == nullptr ||
+          params.array_buffer_allocator == allocator.get());
+    i_isolate->set_array_buffer_allocator(allocator.get());
+    i_isolate->set_array_buffer_allocator_shared(std::move(allocator));
+  } else {
+    CHECK_NOT_NULL(params.array_buffer_allocator);
+    i_isolate->set_array_buffer_allocator(params.array_buffer_allocator);
+  }
+
+  if (params.fatal_error_callback) {
+    cloned_isolate->SetFatalErrorHandler(params.fatal_error_callback);
+  }
+
+#if __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  if (params.oom_error_callback) {
+    cloned_isolate->SetOOMErrorHandler(params.oom_error_callback);
+  }
+#if __clang__
+#pragma clang diagnostic pop
+#endif
+
+  if (params.counter_lookup_callback) {
+    cloned_isolate->SetCounterFunction(params.counter_lookup_callback);
+  }
+
+  if (params.create_histogram_callback) {
+    cloned_isolate->SetCreateHistogramFunction(
+        params.create_histogram_callback);
+  }
+
+  if (params.add_histogram_sample_callback) {
+    cloned_isolate->SetAddHistogramSampleFunction(
+        params.add_histogram_sample_callback);
+  }
+
+  i_isolate->set_api_external_references(params.external_references);
+  i_isolate->set_allow_atomics_wait(params.allow_atomics_wait);
+
+  if (params.constraints.stack_limit() != nullptr) {
+    uintptr_t limit =
+        reinterpret_cast<uintptr_t>(params.constraints.stack_limit());
+    i_isolate->stack_guard()->SetStackLimit(limit);
+  }
+
+  // TODO(v8:2487): Once we got rid of Isolate::Current(), we can remove this.
+  Isolate::Scope isolate_scope(cloned_isolate);
+
+  i_isolate->InitClone(reinterpret_cast<i::Isolate*>(original));
+
+  {
+    // Set up code event handlers. Needs to be after i::Snapshot::Initialize
+    // because that is where we add the isolate to WasmEngine.
+    auto code_event_handler = params.code_event_handler;
+    if (code_event_handler) {
+      cloned_isolate->SetJitCodeEventHandler(kJitCodeEventEnumExisting,
+                                             code_event_handler);
+    }
+  }
+
+  if (!i::V8::GetCurrentPlatform()
+           ->GetForegroundTaskRunner(cloned_isolate)
+           ->NonNestableTasksEnabled()) {
+    FATAL(
+        "The current platform's foreground task runner does not have "
+        "non-nestable tasks enabled. The embedder must provide one.");
+  }
+  return cloned_isolate;
+}
+
 Isolate* Isolate::New(const IsolateGroup& group,
                       const Isolate::CreateParams& params) {
   Isolate* v8_isolate = Allocate(group);

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -9624,9 +9624,15 @@ IsolateGroup& v8::IsolateGroup::operator=(IsolateGroup&& other) {
   return *this;
 }
 
+void v8::IsolateGroup::Freeze() { isolate_group_->Freeze(); }
+
 v8::IsolateGroup v8::IsolateGroup::Clone() {
   i::IsolateGroup* internal_cloned_group = isolate_group_->Clone();
   return IsolateGroup{std::move(internal_cloned_group)};
+}
+
+void v8::IsolateGroup::SetReadOnlyPermissionForSandbox() {
+  isolate_group_->SetReadOnlyPermissionForSandbox();
 }
 
 HeapProfiler* Isolate::GetHeapProfiler() {

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -9624,6 +9624,11 @@ IsolateGroup& v8::IsolateGroup::operator=(IsolateGroup&& other) {
   return *this;
 }
 
+v8::IsolateGroup v8::IsolateGroup::Clone() {
+  i::IsolateGroup* internal_cloned_group = isolate_group_->Clone();
+  return IsolateGroup{std::move(internal_cloned_group)};
+}
+
 HeapProfiler* Isolate::GetHeapProfiler() {
   i::HeapProfiler* heap_profiler =
       reinterpret_cast<i::Isolate*>(this)->heap()->heap_profiler();

--- a/src/codegen/compilation-cache.cc
+++ b/src/codegen/compilation-cache.cc
@@ -361,5 +361,26 @@ void CompilationCache::DisableScriptAndEval() {
   Clear();
 }
 
+void CompilationCache::InitializeClone(CompilationCache* original) {
+  auto rebase =
+      [original_cage = original->isolate()->isolate_group()->GetPtrComprCage(),
+       cloned_cage =
+           isolate_->isolate_group()->GetPtrComprCage()](Address address) {
+        return original_cage->Rebase(address, cloned_cage);
+      };
+  script_.table_ = Tagged<Object>(rebase(original->script_.table_.ptr()));
+
+  eval_global_.table_ =
+      Tagged<Object>(rebase(original->eval_global_.table_.ptr()));
+  eval_contextual_.table_ =
+      Tagged<Object>(rebase(original->eval_contextual_.table_.ptr()));
+
+  reg_exp_.tables_[0] =
+      Tagged<Object>(rebase(original->reg_exp_.tables_[0].ptr()));
+  reg_exp_.tables_[1] =
+      Tagged<Object>(rebase(original->reg_exp_.tables_[1].ptr()));
+  enabled_script_and_eval_ = original->enabled_script_and_eval_;
+}
+
 }  // namespace internal
 }  // namespace v8

--- a/src/codegen/compilation-cache.h
+++ b/src/codegen/compilation-cache.h
@@ -37,6 +37,7 @@ class CompilationCacheEvalOrScript {
   void Remove(DirectHandle<SharedFunctionInfo> function_info);
 
  protected:
+  friend class CompilationCache;
   Isolate* isolate() const { return isolate_; }
 
   Isolate* const isolate_;
@@ -130,6 +131,8 @@ class CompilationCacheRegExp {
   void Clear();
 
  private:
+  friend class CompilationCache;
+
   Isolate* isolate() const { return isolate_; }
 
   Isolate* const isolate_;
@@ -212,7 +215,8 @@ class V8_EXPORT_PRIVATE CompilationCache {
   void EnableScriptAndEval();
   void DisableScriptAndEval();
 
- private:
+  void InitializeClone(CompilationCache* original);
+
   explicit CompilationCache(Isolate* isolate);
   ~CompilationCache() = default;
 

--- a/src/execution/isolate.cc
+++ b/src/execution/isolate.cc
@@ -6068,6 +6068,573 @@ bool Isolate::Init(SnapshotData* startup_snapshot_data,
   return true;
 }
 
+bool Isolate::InitClone(Isolate* original) {
+  TRACE_ISOLATE(init);
+
+#ifdef V8_COMPRESS_POINTERS_IN_SHARED_CAGE
+  CHECK_EQ(V8HeapCompressionScheme::base(), cage_base());
+#endif  // V8_COMPRESS_POINTERS_IN_SHARED_CAGE
+
+  time_millis_at_init_ = original->time_millis_at_init_;
+
+  task_runner_ = V8::GetCurrentPlatform()->GetForegroundTaskRunner(
+      reinterpret_cast<v8::Isolate*>(this));
+
+  isolate_group()->AddIsolate(this);
+  Isolate* const use_shared_space_isolate =
+      isolate_group()->shared_space_isolate();
+#if DEBUG
+  is_shared_space_isolate_initialized_ = true;
+#endif  // DEBUG
+
+  CHECK_IMPLIES(is_shared_space_isolate(), V8_CAN_CREATE_SHARED_HEAP_BOOL);
+
+  force_slow_path_ = v8_flags.force_slow_path;
+
+  flush_denormals_ = base::FPU::GetFlushDenormals();
+
+  has_fatal_error_ = false;
+
+  // The initialization process does not handle memory exhaustion.
+  AlwaysAllocateScope always_allocate(heap());
+
+#define ASSIGN_ELEMENT(CamelName, hacker_name)                  \
+  isolate_addresses_[IsolateAddressId::k##CamelName##Address] = \
+      reinterpret_cast<Address>(hacker_name##_address());
+  FOR_EACH_ISOLATE_ADDRESS_NAME(ASSIGN_ELEMENT)
+#undef ASSIGN_ELEMENT
+
+  // We need to initialize code_pages_ before any on-heap code is allocated to
+  // make sure we record all code allocations.
+  InitializeCodeRanges();
+
+  compilation_cache_ = new CompilationCache(this);
+  compilation_cache_->InitializeClone(original->compilation_cache_);
+  descriptor_lookup_cache_ = new DescriptorLookupCache();
+  global_handles_ = new GlobalHandles(this);
+  eternal_handles_ = new EternalHandles();
+  bootstrapper_ = new Bootstrapper(this);
+  handle_scope_implementer_ = new HandleScopeImplementer(this);
+  load_stub_cache_ = new StubCache(this);
+  store_stub_cache_ = new StubCache(this);
+  define_own_stub_cache_ = new StubCache(this);
+  materialized_object_store_ = new MaterializedObjectStore(this);
+  regexp_stack_ = RegExpStack::New();
+  isolate_data()->set_regexp_static_result_offsets_vector(
+      jsregexp_static_offsets_vector());
+  date_cache_ = new DateCache();
+  interpreter_ = new interpreter::Interpreter(this);
+  bigint_processor_ = bigint::Processor::New(new BigIntPlatform(this));
+
+  if (is_shared_space_isolate()) {
+    global_safepoint_ = std::make_unique<GlobalSafepoint>(this);
+  }
+
+  if (v8_flags.lazy_compile_dispatcher) {
+    lazy_compile_dispatcher_ = std::make_unique<LazyCompileDispatcher>(
+        this, V8::GetCurrentPlatform(), v8_flags.stack_size);
+  }
+#ifdef V8_ENABLE_SPARKPLUG
+  baseline_batch_compiler_ = new baseline::BaselineBatchCompiler(this);
+#endif  // V8_ENABLE_SPARKPLUG
+#ifdef V8_ENABLE_MAGLEV
+  maglev_concurrent_dispatcher_ = new maglev::MaglevConcurrentDispatcher(this);
+#endif  // V8_ENABLE_MAGLEV
+
+#if USE_SIMULATOR
+  simulator_data_ = new SimulatorData;
+#endif
+
+  // Enable logging before setting up the heap
+  v8_file_logger_->SetUp(this);
+
+  metrics_recorder_ = std::make_shared<metrics::Recorder>();
+
+  {
+    // Ensure that the thread has a valid stack guard.  The v8::Locker object
+    // will ensure this too, but we don't have to use lockers if we are only
+    // using one thread.
+    ExecutionAccess lock(this);
+    stack_guard()->InitThread(lock);
+  }
+
+  // Create LocalIsolate/LocalHeap for the main thread and set state to Running.
+  main_thread_local_isolate_.reset(new LocalIsolate(this, ThreadKind::kMain));
+
+  {
+    IgnoreLocalGCRequests ignore_gc_requests(heap());
+    main_thread_local_heap()->Unpark();
+  }
+
+  // Requires a LocalHeap to be set up to register a GC epilogue callback.
+  inner_pointer_to_code_cache_ = new InnerPointerToCodeCache(this);
+
+#if V8_ENABLE_WEBASSEMBLY
+  wasm_code_look_up_cache_ = new wasm::WasmCodeLookupCache;
+#endif  // V8_ENABLE_WEBASSEMBLY
+
+  // Lock clients_mutex_ in order to prevent shared GCs from other clients
+  // during deserialization.
+  std::optional<base::RecursiveMutexGuard> clients_guard;
+
+  if (use_shared_space_isolate && !is_shared_space_isolate()) {
+    clients_guard.emplace(
+        &use_shared_space_isolate->global_safepoint()->clients_mutex_);
+    use_shared_space_isolate->global_safepoint()->AppendClient(this);
+  }
+
+  shared_space_isolate_ = use_shared_space_isolate;
+
+  isolate_data_.is_shared_space_isolate_flag_ = is_shared_space_isolate();
+  isolate_data_.uses_shared_heap_flag_ = has_shared_space();
+
+  if (use_shared_space_isolate && !is_shared_space_isolate() &&
+      use_shared_space_isolate->heap()
+          ->incremental_marking()
+          ->IsMajorMarking()) {
+    heap_.SetIsMarkingFlag(true);
+  }
+
+  // Set up the object heap.
+  DCHECK(!heap_.HasBeenSetUp());
+  heap_.SetUpClone(main_thread_local_heap(), original->heap());
+  InitializeIsShortBuiltinCallsEnabled();
+#ifdef V8_ENABLE_SANDBOX
+  auto trusted_cage_rebase =
+      [original_trusted_cage =
+           original->isolate_group()->GetTrustedPtrComprCage(),
+       cloned_trusted_cage = isolate_group()->GetTrustedPtrComprCage()](
+          Address trusted_object_pointer) {
+        return original_trusted_cage->Rebase(trusted_object_pointer,
+                                             cloned_trusted_cage);
+      };
+#endif
+
+#ifdef V8_COMPRESS_POINTERS
+  auto ept_rebase =
+      [original_pointer_cage = original->isolate_group()->GetPtrComprCage(),
+       original_code_cage = original->isolate_group()->GetCodeRange(),
+       original_trust_cage =
+           original->isolate_group()->GetTrustedPtrComprCage()](
+          Address external_pointer) {
+        DCHECK(!original_pointer_cage->Contains(external_pointer));
+        DCHECK(!original_code_cage->Contains(external_pointer));
+        DCHECK(!original_trust_cage->Contains(external_pointer));
+        return external_pointer;
+      };
+#endif
+  {
+    // Must be done before deserializing RO space since the deserialization
+    // process refers to these data structures.
+    isolate_data_.external_reference_table()->InitIsolateIndependent(
+        isolate_group()->external_ref_table());
+#ifdef V8_COMPRESS_POINTERS
+    external_pointer_table().Initialize();
+
+    external_pointer_table().InitializeSpace(
+        heap()->read_only_external_pointer_space());
+    external_pointer_table().AttachSpaceToReadOnlySegments(
+        heap()->read_only_external_pointer_space());
+    external_pointer_table().InitializeSpace(
+        heap()->young_external_pointer_space());
+    external_pointer_table().InitializeSpace(
+        heap()->old_external_pointer_space());
+    external_pointer_table().CloneSpaceFrom(
+        &original->external_pointer_table(),
+        original->heap()->old_external_pointer_space(),
+        heap()->old_external_pointer_space(), ept_rebase);
+    external_pointer_table().CloneSpaceFrom(
+        &original->external_pointer_table(),
+        original->heap()->young_external_pointer_space(),
+        heap()->young_external_pointer_space(), ept_rebase);
+
+    cpp_heap_pointer_table().Initialize();
+    cpp_heap_pointer_table().InitializeSpace(heap()->cpp_heap_pointer_space());
+#endif  // V8_COMPRESS_POINTERS
+
+#ifdef V8_ENABLE_SANDBOX
+    trusted_pointer_table().Initialize();
+    trusted_pointer_table().InitializeSpace(heap()->trusted_pointer_space());
+    trusted_pointer_table().CloneSpaceFrom(
+        &original->trusted_pointer_table(),
+        original->heap()->trusted_pointer_space(),
+        heap()->trusted_pointer_space(), trusted_cage_rebase);
+
+#endif  // V8_ENABLE_SANDBOX
+  }
+
+  {
+    // LocalHeap initialization requires the TLS variable to be set already.
+    // However, we can't move SetIsolateThreadLocals here because the marking
+    // barrier isn't setup yet.
+    SetCurrentLocalHeapScope local_heap_scope(this);
+    isolate_group()->SetupReadOnlyHeapClone(this, original);
+
+    // Rebase read-only roots.
+    for (RootIndex i = RootIndex::kFirstRoot; i != RootIndex::kRootListLength;
+         ++i) {
+      if (RootsTable::IsReadOnly(i)) {
+        // They are initialized inside SetupReadOnlyHeapClone.
+        continue;
+      }
+
+      const RootsTable& original_ro_table = original->isolate_data()->roots();
+      RootsTable& cloned_ro_table = isolate_data()->roots();
+      if (auto* original_trusted_cage =
+              original->isolate_group()->GetTrustedPtrComprCage();
+          original_trusted_cage->Contains(original_ro_table[i])) {
+        // Trusted roots use their own trusted cage.
+        cloned_ro_table[i] = original_trusted_cage->Rebase(
+            original_ro_table[i], isolate_group()->GetTrustedPtrComprCage());
+        continue;
+      }
+
+      if (auto* original_pointer_cage =
+              original->isolate_group()->GetPtrComprCage();
+          original_pointer_cage->Contains(original_ro_table[i])) {
+        cloned_ro_table[i] = original_pointer_cage->Rebase(
+            original_ro_table[i], isolate_group()->GetPtrComprCage());
+        continue;
+      }
+
+      cloned_ro_table[i] = original_ro_table[i];
+    }
+
+    heap_.SetUpSpacesClone(original->heap());
+  }
+
+  // Need to do this after setupping heap spaces.
+  global_handles_->CopyStateFrom(original->global_handles());
+  traced_handles_.CopyStateFrom(original->traced_handles());
+  eternal_handles_->CopyStateFrom(original->eternal_handles());
+
+  DCHECK_EQ(this, Isolate::Current());
+  PerIsolateThreadData* const current_data = CurrentPerIsolateThreadData();
+  DCHECK_EQ(current_data->isolate(), this);
+  SetIsolateThreadLocals(this, current_data);
+
+  if (OwnsStringTables()) {
+    string_table_ =
+        std::unique_ptr<StringTable>(original->string_table_->Clone(this));
+    string_forwarding_table_ = std::unique_ptr<StringForwardingTable>(
+        original->string_forwarding_table_->Clone(this));
+  } else {
+    // Only refer to shared string table after attaching to the shared isolate.
+    DCHECK(has_shared_space());
+    DCHECK(!is_shared_space_isolate());
+    DCHECK_NOT_NULL(string_table());
+    DCHECK_NOT_NULL(string_forwarding_table());
+  }
+
+#ifdef V8_EXTERNAL_CODE_SPACE
+  {
+    VirtualMemoryCage* code_cage;
+    if (heap_.code_range()) {
+      code_cage = heap_.code_range();
+    } else {
+      CHECK(jitless_);
+      // In jitless mode the code space pages will be allocated in the main
+      // pointer compression cage.
+      code_cage = isolate_group_->GetPtrComprCage();
+    }
+    code_cage_base_ = ExternalCodeCompressionScheme::PrepareCageBaseAddress(
+        code_cage->base());
+    if (COMPRESS_POINTERS_IN_MULTIPLE_CAGES_BOOL) {
+      // .. now that it's available, initialize the thread-local base.
+      ExternalCodeCompressionScheme::InitBase(code_cage_base_);
+    }
+    CHECK_EQ(ExternalCodeCompressionScheme::base(), code_cage_base_);
+
+    // Ensure that ExternalCodeCompressionScheme is applicable to all objects
+    // stored in the code cage.
+    using ComprScheme = ExternalCodeCompressionScheme;
+    Address base = code_cage->base() + kHeapObjectTag;
+    Address last = base + code_cage->size() - kTaggedSize;
+    Address upper_bound = base + kPtrComprCageReservationSize - kTaggedSize;
+    PtrComprCageBase code_cage_base{code_cage_base_};
+    CHECK_EQ(base,
+             ComprScheme::DecompressTagged(ComprScheme::CompressAny(base)));
+    CHECK_EQ(last,
+             ComprScheme::DecompressTagged(ComprScheme::CompressAny(last)));
+    CHECK_EQ(upper_bound, ComprScheme::DecompressTagged(
+                              ComprScheme::CompressAny(upper_bound)));
+  }
+#endif  // V8_EXTERNAL_CODE_SPACE
+
+  isolate_data_.external_reference_table()->Init(this);
+
+#ifdef V8_COMPRESS_POINTERS
+  if (owns_shareable_data()) {
+    isolate_data_.shared_external_pointer_table_ = new ExternalPointerTable();
+    shared_external_pointer_space_ = new ExternalPointerTable::Space();
+    shared_external_pointer_table().Initialize();
+    shared_external_pointer_table().InitializeSpace(
+        shared_external_pointer_space());
+    shared_external_pointer_table().CloneSpaceFrom(
+        &original->shared_external_pointer_table(),
+        original->shared_external_pointer_space(),
+        shared_external_pointer_space(), ept_rebase);
+  } else {
+    DCHECK(has_shared_space());
+    isolate_data_.shared_external_pointer_table_ =
+        shared_space_isolate()->isolate_data_.shared_external_pointer_table_;
+    shared_external_pointer_space_ =
+        shared_space_isolate()->shared_external_pointer_space_;
+  }
+#endif  // V8_COMPRESS_POINTERS
+
+#ifdef V8_ENABLE_SANDBOX
+  isolate_group()->code_pointer_table()->InitializeSpace(
+      heap()->code_pointer_space());
+
+  auto code_cage_rebase = [original_code_cage =
+                               original->isolate_group()->GetCodeRange(),
+                           cloned_code_cage = isolate_group()->GetCodeRange()](
+                              Address original_entrypoint) {
+    return original_code_cage->Rebase(original_entrypoint, cloned_code_cage);
+  };
+  auto pointer_and_trusted_cage_remapping =
+      [original_cage = original->isolate_group()->GetPtrComprCage(),
+       cloned_cage = isolate_group()->GetPtrComprCage(),
+       trusted_cage_rebase](Address original_code_object) {
+        if (original_cage->Contains(original_code_object)) {
+          return original_cage->Rebase(original_code_object, cloned_cage);
+        }
+
+        return trusted_cage_rebase(original_code_object);
+      };
+  isolate_group()->code_pointer_table()->CloneSpaceFrom(
+      original->isolate_group()->code_pointer_table(),
+      original->heap()->code_pointer_space(), heap()->code_pointer_space(),
+      code_cage_rebase, pointer_and_trusted_cage_remapping);
+
+  if (owns_shareable_data()) {
+    isolate_data_.shared_trusted_pointer_table_ = new TrustedPointerTable();
+    shared_trusted_pointer_space_ = new TrustedPointerTable::Space();
+    shared_trusted_pointer_table().Initialize();
+    shared_trusted_pointer_table().InitializeSpace(
+        shared_trusted_pointer_space());
+    shared_trusted_pointer_table().CloneSpaceFrom(
+        &original->shared_trusted_pointer_table(),
+        original->shared_trusted_pointer_space(),
+        shared_trusted_pointer_space(), trusted_cage_rebase);
+  } else {
+    DCHECK(has_shared_space());
+    isolate_data_.shared_trusted_pointer_table_ =
+        shared_space_isolate()->isolate_data_.shared_trusted_pointer_table_;
+    shared_trusted_pointer_space_ =
+        shared_space_isolate()->shared_trusted_pointer_space_;
+  }
+
+#endif  // V8_ENABLE_SANDBOX
+
+#ifdef V8_EXTERNAL_CODE_SPACE
+  // There are code object inside code space that have embedded absolute
+  // addreses into the original trusted cage, like ByteCodeArray. Since we have
+  // a new trusted cage we update those addresses here.
+  heap_.RebaseAbsolutePointersToTrustedCage(
+      original->isolate_group()->GetTrustedPtrComprCage());
+#endif
+
+#ifdef V8_ENABLE_LEAPTIERING
+  isolate_group()->js_dispatch_table()->InitializeSpace(
+      heap()->js_dispatch_table_space());
+#endif  // V8_ENABLE_LEAPTIERING
+
+#if V8_ENABLE_WEBASSEMBLY
+  wasm::GetWasmEngine()->AddIsolate(this);
+#endif  // V8_ENABLE_WEBASSEMBLY
+
+#if defined(V8_ENABLE_ETW_STACK_WALKING)
+  if (v8_flags.enable_etw_stack_walking ||
+      v8_flags.enable_etw_by_custom_filter_only) {
+    ETWJITInterface::AddIsolate(this);
+  }
+#endif  // defined(V8_ENABLE_ETW_STACK_WALKING)
+
+  if (setup_delegate_ == nullptr) {
+    setup_delegate_ = new SetupIsolateDelegate;
+  }
+
+  if (!v8_flags.inline_new) heap_.DisableInlineAllocation();
+
+  if (!setup_delegate_->SetupHeap(this, false)) {
+    V8::FatalProcessOutOfMemory(this, "heap object creation");
+  }
+
+  InitializeThreadLocal();
+
+  // Profiler has to be created after ThreadLocal is initialized
+  // because it makes use of interrupts.
+  tracing_cpu_profiler_.reset(new TracingCpuProfilerImpl(this));
+
+  bootstrapper_->CloneDataFrom(original->bootstrapper_);
+  setup_delegate_->SetupBuiltins(this, false);
+
+  // Initialize custom memcopy and memmove functions (must happen after
+  // embedded blob setup).
+  init_memcopy_functions();
+
+  if ((v8_flags.trace_turbo || v8_flags.trace_turbo_graph ||
+       v8_flags.turbo_profiling) &&
+      !v8_flags.concurrent_turbo_tracing) {
+    PrintF("Concurrent recompilation has been disabled for tracing.\n");
+  } else if (OptimizingCompileDispatcher::Enabled()) {
+    optimizing_compile_dispatcher_ = new OptimizingCompileDispatcher(
+        this, isolate_group_->optimizing_compile_task_executor());
+  }
+
+  // Initialize before deserialization since collections may occur,
+  // clearing/updating ICs (and thus affecting tiering decisions).
+  tiering_manager_ = new TieringManager(this);
+
+  // Rebase startup and shared object caches.
+  {
+    // Initialize startup and shared object caches.
+    auto* original_cage = original->isolate_group()->GetPtrComprCage();
+    auto* cloned_cage = isolate_group()->GetPtrComprCage();
+    startup_object_cache_.reserve(original->startup_object_cache()->size());
+    for (Tagged<Object> original_obj : *original->startup_object_cache()) {
+      startup_object_cache_.push_back(Tagged<Object>(
+          original_cage->Rebase(original_obj.ptr(), cloned_cage)));
+    }
+
+    shared_heap_object_cache_.reserve(
+        original->shared_heap_object_cache()->size());
+    for (Tagged<Object> original_obj : *original->shared_heap_object_cache()) {
+      shared_heap_object_cache_.push_back(Tagged<Object>(
+          original_cage->Rebase(original_obj.ptr(), cloned_cage)));
+    }
+  }
+
+  // Copy and rebase JS dispatch table.
+  {
+    CloneBuiltinTable(original);
+    heap()->set_native_contexts_list(ReadOnlyRoots(this).undefined_value());
+    if (heap()->allocation_sites_list() == Smi::zero()) {
+      heap()->set_allocation_sites_list(ReadOnlyRoots(this).undefined_value());
+    }
+    heap()->set_dirty_js_finalization_registries_list(
+        ReadOnlyRoots(this).undefined_value());
+    heap()->set_dirty_js_finalization_registries_list_tail(
+        ReadOnlyRoots(this).undefined_value());
+    builtins_.MarkInitialized();
+
+    auto entrypoint_remapping =
+        [original_code_cage = original->isolate_group()->GetCodeRange(),
+         cloned_code_cage =
+             isolate_group()->GetCodeRange()](Address original_entrypoint) {
+          if (!original_code_cage->Contains(original_entrypoint)) {
+            // It is a pointer to some C++ function.
+            return original_entrypoint;
+          }
+          return original_code_cage->Rebase(original_entrypoint,
+                                            cloned_code_cage);
+        };
+    isolate_group()->js_dispatch_table()->CloneSpaceFrom(
+        original->isolate_group()->js_dispatch_table(),
+        original->heap()->js_dispatch_table_space(),
+        heap()->js_dispatch_table_space(), entrypoint_remapping,
+        pointer_and_trusted_cage_remapping);
+  }
+
+  InitializeBuiltinJSDispatchTable();
+  if (DEBUG_BOOL) VerifyStaticRoots();
+  load_stub_cache_->Initialize();
+  store_stub_cache_->Initialize();
+  define_own_stub_cache_->Initialize();
+  interpreter_->Initialize();
+  heap()->complete_deserialization();
+
+  delete setup_delegate_;
+  setup_delegate_ = nullptr;
+
+  Builtins::InitializeIsolateDataTables(this);
+
+  // Extra steps in the logger after the heap has been set up.
+  v8_file_logger_->LateSetup(this);
+
+  if (v8_flags.print_builtin_code) builtins()->PrintBuiltinCode();
+  if (v8_flags.print_builtin_size) builtins()->PrintBuiltinSize();
+
+  // Finish initialization of ThreadLocal after deserialization is done.
+  clear_exception();
+  clear_pending_message();
+
+  // Quiet the heap NaN if needed on target platform.
+  Assembler::QuietNaN(ReadOnlyRoots(this).nan_value());
+
+  if (v8_flags.trace_turbo) {
+    // Create an empty file.
+    std::ofstream(GetTurboCfgFileName(this).c_str(), std::ios_base::trunc);
+  }
+
+  isolate_data_.continuation_preserved_embedder_data_ =
+      *factory()->undefined_value();
+
+  {
+    HandleScope scope(this);
+    ast_string_constants_ = new AstStringConstants(this, HashSeed(this));
+  }
+
+  // TODO(dbezhetskov): should be false.
+  initialized_from_snapshot_ = true;
+
+  if (v8_flags.stress_sampling_allocation_profiler > 0) {
+    uint64_t sample_interval = v8_flags.stress_sampling_allocation_profiler;
+    int stack_depth = 128;
+    v8::HeapProfiler::SamplingFlags sampling_flags =
+        v8::HeapProfiler::SamplingFlags::kSamplingForceGC;
+    heap()->heap_profiler()->StartSamplingHeapProfiler(
+        sample_interval, stack_depth, sampling_flags);
+  }
+
+  if (v8_flags.harmony_struct) {
+    // Initialize or get the struct type registry shared by all isolates.
+    if (is_shared_space_isolate()) {
+      shared_struct_type_registry_ =
+          std::make_unique<SharedStructTypeRegistry>();
+    } else {
+      DCHECK_NOT_NULL(shared_struct_type_registry());
+    }
+  }
+
+#ifdef V8_ENABLE_WEBASSEMBLY
+#if V8_STATIC_ROOTS_BOOL
+  // Protect the payload of wasm null.
+  if (!page_allocator()->DecommitPages(
+          reinterpret_cast<void*>(factory()->wasm_null()->first_payload()),
+          WasmNull::kFirstPayloadSize)) {
+    V8::FatalProcessOutOfMemory(this, "decommitting WasmNull payload");
+  }
+  if (v8_flags.unmap_holes) {
+    // Protect the second payload of wasm null, containing the holes.
+    if (!page_allocator()->DecommitPages(
+            reinterpret_cast<void*>(factory()->wasm_null()->second_payload()),
+            WasmNull::kSecondPayloadSize)) {
+      V8::FatalProcessOutOfMemory(
+          this, "decommitting second WasmNull payload (holes)");
+    }
+  }
+#endif  // V8_STATIC_ROOTS_BOOL
+#endif  // V8_ENABLE_WEBASSEMBLY
+
+#if defined(V8_ENABLE_ETW_STACK_WALKING)
+  if (v8_flags.enable_etw_stack_walking ||
+      v8_flags.enable_etw_by_custom_filter_only) {
+    ETWJITInterface::MaybeSetHandlerNow(this);
+  }
+#endif  // defined(V8_ENABLE_ETW_STACK_WALKING)
+
+#if defined(V8_USE_PERFETTO)
+  PerfettoLogger::RegisterIsolate(this);
+#endif  // defined(V8_USE_PERFETTO)
+
+  initialized_ = true;
+
+  return true;
+}
+
 void Isolate::Enter() {
   Isolate* current_isolate = nullptr;
   PerIsolateThreadData* current_data = CurrentPerIsolateThreadData();
@@ -8023,6 +8590,32 @@ void Isolate::PrintNumberStringCacheStats(const char* comment,
            v8_flags.double_string_cache_size.value());
   }
   PrintF("\n");
+}
+
+void Isolate::CloneBuiltinTable(Isolate* original) {
+  base::MutexGuard guard(read_only_dispatch_entries_mutex_.Pointer());
+
+  // Initialize builtin_table_ and builtin_entry_table_.
+  const auto& original_builtin_table = original->isolate_data()->builtin_table_;
+  const auto& original_builtin_entry_table =
+      original->isolate_data()->builtin_entry_table_;
+  auto* original_cage = original->isolate_group()->GetPtrComprCage();
+  auto& clone_builtin_table = isolate_data()->builtin_table_;
+  auto& clone_builtin_entry_table = isolate_data()->builtin_entry_table_;
+  auto* cloned_cage = isolate_group()->GetPtrComprCage();
+  for (size_t i = 0; i < Builtins::kBuiltinCount; ++i) {
+    clone_builtin_table[i] =
+        original_cage->Rebase(original_builtin_table[i], cloned_cage);
+
+    Address original_builtin_entry = original_builtin_entry_table[i];
+    if (original_cage->Contains(original_builtin_entry)) {
+      clone_builtin_entry_table[i] =
+          original_cage->Rebase(original_builtin_entry, cloned_cage);
+    } else {
+      // It can be an address to the C++ runtime.
+      clone_builtin_entry_table[i] = original_builtin_entry;
+    }
+  }
 }
 
 }  // namespace internal

--- a/src/execution/isolate.h
+++ b/src/execution/isolate.h
@@ -2430,6 +2430,8 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
 
   void PrintNumberStringCacheStats(const char* comment, bool final_summary);
 
+  bool InitClone(Isolate* target);
+
  private:
   explicit Isolate(IsolateGroup* isolate_group);
   ~Isolate();
@@ -2802,6 +2804,7 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
   void ClearEmbeddedBlob();
 
   void InitializeBuiltinJSDispatchTable();
+  void CloneBuiltinTable(Isolate* original);
 
   const uint8_t* embedded_blob_code_ = nullptr;
   uint32_t embedded_blob_code_size_ = 0;

--- a/src/handles/global-handles.cc
+++ b/src/handles/global-handles.cc
@@ -611,6 +611,40 @@ GlobalHandles::GlobalHandles(Isolate* isolate)
     : isolate_(isolate),
       regular_nodes_(std::make_unique<NodeSpace<GlobalHandles::Node>>(this)) {}
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+void GlobalHandles::CopyStateFrom(GlobalHandles* original) {
+  auto* original_pointer_cage =
+      original->isolate()->isolate_group()->GetPtrComprCage();
+  auto* cloned_pointer_cage = isolate()->isolate_group()->GetPtrComprCage();
+
+  for (Node* node : *original->regular_nodes_) {
+    const Address object_addr = node->object().ptr();
+    if (object_addr == kGlobalHandleZapValue) {
+      continue;
+    }
+    Create(original_pointer_cage->Rebase(object_addr, cloned_pointer_cage));
+  }
+
+  for (Node* node : original->young_nodes_) {
+    const Address object_addr = node->object().ptr();
+    if (object_addr == kGlobalHandleZapValue) {
+      continue;
+    }
+    Create(original_pointer_cage->Rebase(object_addr, cloned_pointer_cage));
+  }
+}
+
+Address* GlobalHandles::FindGlobalHandleLocation(Address value) {
+  for (Node* node : *regular_nodes_) {
+    if (node->object().ptr() == value) {
+      return node->handle().location();
+    }
+  }
+  DCHECK(false);
+  return nullptr;
+}
+#endif
+
 GlobalHandles::~GlobalHandles() = default;
 
 namespace {
@@ -1040,6 +1074,13 @@ void EternalHandles::PostGarbageCollectionProcessing() {
   DCHECK_LE(last, young_node_indices_.size());
   young_node_indices_.resize(last);
 }
+
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+void EternalHandles::CopyStateFrom(EternalHandles* original) {
+  DCHECK(original->young_node_indices_.empty());
+  DCHECK(original->blocks_.empty());
+}
+#endif
 
 void EternalHandles::Create(Isolate* isolate, Tagged<Object> object,
                             int* index) {

--- a/src/handles/global-handles.h
+++ b/src/handles/global-handles.h
@@ -70,6 +70,12 @@ class V8_EXPORT_PRIVATE GlobalHandles final {
   explicit GlobalHandles(Isolate* isolate);
   ~GlobalHandles();
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  void CopyStateFrom(GlobalHandles* original);
+
+  Address* FindGlobalHandleLocation(Address value);
+#endif
+
   // Creates a new global handle that is alive until Destroy is called.
   IndirectHandle<Object> Create(Tagged<Object> value);
   IndirectHandle<Object> Create(Address value);
@@ -213,6 +219,10 @@ class EternalHandles final {
   void PostGarbageCollectionProcessing();
 
   size_t handles_count() const { return size_; }
+
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  void CopyStateFrom(EternalHandles* original);
+#endif
 
  private:
   static const int kInvalidIndex = -1;

--- a/src/handles/traced-handles.cc
+++ b/src/handles/traced-handles.cc
@@ -846,4 +846,10 @@ bool TracedHandles::IsValidInUseNode(const Address* location) {
 
 bool TracedHandles::HasYoung() const { return !young_blocks_.empty(); }
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+void TracedHandles::CopyStateFrom(TracedHandles* original) {
+  DCHECK(original->blocks_.empty());
+}
+#endif
+
 }  // namespace v8::internal

--- a/src/handles/traced-handles.h
+++ b/src/handles/traced-handles.h
@@ -335,6 +335,10 @@ class V8_EXPORT_PRIVATE TracedHandles final {
 
   bool HasYoung() const;
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  void CopyStateFrom(TracedHandles* original);
+#endif
+
  private:
   V8_INLINE std::pair<TracedNodeBlock*, TracedNode*> AllocateNode();
   V8_NOINLINE V8_PRESERVE_MOST void RefillUsableNodeBlocks();

--- a/src/heap/heap.h
+++ b/src/heap/heap.h
@@ -682,6 +682,11 @@ class Heap final {
 
   bool deserialization_complete() const { return deserialization_complete_; }
 
+  void complete_deserialization() {
+    DCHECK(!deserialization_complete_);
+    deserialization_complete_ = true;
+  }
+
   // We can only invoke Safepoint() on the main thread local heap after
   // deserialization is complete. Before that, main_thread_local_heap_ might be
   // null.

--- a/src/init/bootstrapper.cc
+++ b/src/init/bootstrapper.cc
@@ -142,6 +142,30 @@ Bootstrapper::Bootstrapper(Isolate* isolate)
       nesting_(0),
       extensions_cache_(Script::Type::kExtension) {}
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+void Bootstrapper::CloneDataFrom(Bootstrapper* original) {
+  nesting_ = original->nesting_;
+  extensions_cache_.CloneDataFrom(original->isolate_,
+                                  &original->extensions_cache_, isolate_);
+}
+
+void SourceCodeCache::CloneDataFrom(Isolate* original_isolate,
+                                    SourceCodeCache* original,
+                                    Isolate* clone_isolate) {
+  type_ = original->type_;
+  auto rebase =
+      [original_cage = original_isolate->isolate_group()->GetPtrComprCage(),
+       current_cage =
+           clone_isolate->isolate_group()->GetPtrComprCage()](Address address) {
+        return original_cage->Rebase(address, current_cage);
+      };
+  Address original_cache_address = original->cache_.ptr();
+  Tagged<FixedArray> cloned_cache = Cast<FixedArray>(
+      HeapObject::FromAddress(rebase(original_cache_address) - kHeapObjectTag));
+  cache_ = std::move(cloned_cache);
+}
+#endif
+
 void Bootstrapper::Initialize(bool create_heap_objects) {
   extensions_cache_.Initialize(isolate_, create_heap_objects);
 }

--- a/src/init/bootstrapper.h
+++ b/src/init/bootstrapper.h
@@ -36,6 +36,11 @@ class SourceCodeCache final {
   void Add(Isolate* isolate, base::Vector<const char> name,
            DirectHandle<SharedFunctionInfo> shared);
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  void CloneDataFrom(Isolate* original_isolate, SourceCodeCache* original,
+                     Isolate* clone_isolate);
+#endif
+
  private:
   Script::Type type_;
   Tagged<FixedArray> cache_;
@@ -47,6 +52,10 @@ class Bootstrapper final {
  public:
   Bootstrapper(const Bootstrapper&) = delete;
   Bootstrapper& operator=(const Bootstrapper&) = delete;
+
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  void CloneDataFrom(Bootstrapper* original);
+#endif
 
   static void InitializeOncePerProcess();
 

--- a/src/init/isolate-group.cc
+++ b/src/init/isolate-group.cc
@@ -373,12 +373,29 @@ IsolateGroup* IsolateGroup::Clone() {
 #endif
 }
 
+void IsolateGroup::SetReadOnlyPermissionForSandbox() {
+  DCHECK(sandbox()->page_allocator()->SetPermissions(
+      reinterpret_cast<void*>(sandbox()->base()), sandbox()->size(),
+      PageAllocator::kRead));
+}
+
 void IsolateGroup::Release() {
   DCHECK_LT(0, reference_count_.load());
 
   if (--reference_count_ == 0) {
     delete this;
   }
+}
+
+void IsolateGroup::Freeze() {
+  for (Isolate* isolate : isolates_) {
+    isolate->Enter();
+    isolate->Freeze(true);
+    isolate->Exit();
+  }
+
+  // Protect the original sandbox from modifications.
+  SetReadOnlyPermissionForSandbox();
 }
 
 namespace {

--- a/src/init/isolate-group.cc
+++ b/src/init/isolate-group.cc
@@ -22,6 +22,11 @@
 #include "src/utils/memcopy.h"
 #include "src/utils/utils.h"
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+#include <algorithm>
+#include <iterator>
+#endif
+
 #ifdef V8_ENABLE_PARTITION_ALLOC
 #include <partition_alloc/partition_alloc.h>
 #endif
@@ -298,6 +303,75 @@ void IsolateGroup::InitializeOncePerProcess() {
 
 // static
 void IsolateGroup::TearDownOncePerProcess() { ReleaseDefault(); }
+
+IsolateGroup* IsolateGroup::Clone() {
+#ifndef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  FATAL(
+      "Cloning isolate groups requires enabling "
+      "multiple pointer compression cages at build-time");
+#else
+  IsolateGroup* previous_group = IsolateGroup::current();
+  IsolateGroup* clonned_group = new IsolateGroup;
+  IsolateGroup::set_current(clonned_group);
+
+  Sandbox* previous_sandbox = Sandbox::current();
+  Sandbox* clonned_sandbox = sandbox()->Clone(GetPlatformVirtualAddressSpace());
+  if (!clonned_sandbox) {
+    return nullptr;
+  }
+  Sandbox::set_current(clonned_sandbox);
+
+  PtrComprCageReservationParams params;
+  Address base = clonned_sandbox->address_space()->AllocatePages(
+      clonned_sandbox->base(), params.reservation_size, params.base_alignment,
+      PagePermissions::kNoAccess);
+  CHECK_EQ(clonned_sandbox->base(), base);
+  base::AddressRegion existing_reservation(base, params.reservation_size);
+  params.page_allocator = clonned_sandbox->page_allocator();
+
+  if (!clonned_group->reservation_.InitReservation(params,
+                                                   existing_reservation)) {
+    V8::FatalProcessOutOfMemory(
+        nullptr,
+        "Failed to reserve virtual memory for process-wide V8 "
+        "pointer compression cage");
+  }
+
+  clonned_group->page_allocator_ = clonned_group->reservation_.page_allocator();
+  clonned_group->pointer_compression_cage_ = &clonned_group->reservation_;
+  DCHECK_NE(trusted_range_.underlying_memory_file_, kInvalidSharedMemoryHandle);
+  if (!clonned_group->trusted_range_.InitReservation(kMaximalTrustedRangeSize,
+                                                     &trusted_range_)) {
+    V8::FatalProcessOutOfMemory(
+        nullptr, "Failed to reserve virtual memory for TrustedRange");
+  }
+  clonned_group->trusted_pointer_compression_cage_ =
+      &clonned_group->trusted_range_;
+  clonned_group->sandbox_ = clonned_sandbox;
+
+  // Initialize clonned group.
+  {
+    clonned_group->process_wide_ = false;
+
+    clonned_group->code_pointer_table()->Initialize();
+    clonned_group->optimizing_compile_task_executor_ =
+        std::make_unique<OptimizingCompileTaskExecutor>();
+    clonned_group->memory_pool_ = std::make_unique<MemoryPool>();
+
+    clonned_group->js_dispatch_table()->Initialize();
+    ExternalReferenceTable::InitializeOncePerIsolateGroup(
+        clonned_group->external_ref_table());
+  }
+
+  V8HeapCompressionScheme::InitBase(clonned_group->GetPtrComprCageBase());
+  ExternalCodeCompressionScheme::InitBase(V8HeapCompressionScheme::base());
+
+  Sandbox::set_current(previous_sandbox);
+  IsolateGroup::set_current(previous_group);
+
+  return clonned_group;
+#endif
+}
 
 void IsolateGroup::Release() {
   DCHECK_LT(0, reference_count_.load());

--- a/src/init/isolate-group.h
+++ b/src/init/isolate-group.h
@@ -207,6 +207,8 @@ class V8_EXPORT_PRIVATE IsolateGroup final {
 
   IsolateGroup* Clone();
 
+  void SetReadOnlyPermissionForSandbox();
+
   // Obtain a fresh reference on the isolate group.
   IsolateGroup* Acquire() {
     DCHECK_LT(0, reference_count_.load());
@@ -217,6 +219,9 @@ class V8_EXPORT_PRIVATE IsolateGroup final {
   // Release a reference on an isolate group, possibly freeing any shared memory
   // resources.
   void Release();
+
+  // Freezes all isolates in the isolate group.
+  void Freeze();
 
   v8::PageAllocator* page_allocator() const { return page_allocator_; }
   v8::PageAllocator* read_only_page_allocator() const {

--- a/src/init/isolate-group.h
+++ b/src/init/isolate-group.h
@@ -205,6 +205,8 @@ class V8_EXPORT_PRIVATE IsolateGroup final {
   static void InitializeOncePerProcess();
   static void TearDownOncePerProcess();
 
+  IsolateGroup* Clone();
+
   // Obtain a fresh reference on the isolate group.
   IsolateGroup* Acquire() {
     DCHECK_LT(0, reference_count_.load());

--- a/src/objects/string-forwarding-table.cc
+++ b/src/objects/string-forwarding-table.cc
@@ -169,6 +169,15 @@ StringForwardingTable::~StringForwardingTable() {
   }
 }
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+std::unique_ptr<StringForwardingTable> StringForwardingTable::Clone(
+    Isolate* isolate) {
+  auto cloned_table = std::make_unique<StringForwardingTable>(isolate);
+  DCHECK_EQ(size(), 0);
+  return cloned_table;
+}
+#endif
+
 void StringForwardingTable::InitializeBlockVector() {
   BlockVector* blocks = block_vector_storage_
                             .emplace_back(std::make_unique<BlockVector>(

--- a/src/objects/string-forwarding-table.h
+++ b/src/objects/string-forwarding-table.h
@@ -38,6 +38,10 @@ class StringForwardingTable {
   explicit StringForwardingTable(Isolate* isolate);
   ~StringForwardingTable();
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  std::unique_ptr<StringForwardingTable> Clone(Isolate* isolate);
+#endif
+
   inline int size() const;
   inline bool empty() const;
   // Returns the index of the added record.

--- a/src/objects/string-table.cc
+++ b/src/objects/string-table.cc
@@ -86,6 +86,10 @@ class StringTable::Data {
   static std::unique_ptr<Data> Resize(PtrComprCageBase cage_base,
                                       std::unique_ptr<Data> data, int capacity);
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  static std::unique_ptr<Data> Clone(PtrComprCageBase cage_base, Data* target);
+#endif
+
   void* operator new(size_t size, int capacity);
   void* operator new(size_t size) = delete;
   void operator delete(void* description);
@@ -148,6 +152,19 @@ std::unique_ptr<StringTable::Data> StringTable::Data::Resize(
   return new_data;
 }
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+std::unique_ptr<v8::internal::StringTable::Data> StringTable::Data::Clone(
+    PtrComprCageBase cage_base, Data* target) {
+  int capacity = target->table().capacity();
+  std::unique_ptr<Data> new_data(new (capacity) Data(capacity));
+  target->table_.RehashInto(cage_base, &new_data->table_);
+  if (target->previous_data_) {
+    new_data->previous_data_ = Clone(cage_base, target->previous_data_.get());
+  }
+  return new_data;
+}
+#endif
+
 void StringTable::Data::Print(PtrComprCageBase cage_base) const {
   OFStream os(stdout);
   os << "StringTable {" << std::endl;
@@ -166,6 +183,21 @@ StringTable::StringTable(Isolate* isolate)
 }
 
 StringTable::~StringTable() { delete data_; }
+
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+std::unique_ptr<StringTable> StringTable::Clone(Isolate* isolate) {
+  auto cloned_table = std::make_unique<StringTable>(isolate);
+  {
+    base::MutexGuard table_write_guard(&cloned_table->write_mutex_);
+    // No need to guard data_ because it should be frozen.
+    cloned_table->data_.store(
+        StringTable::Data::Clone(isolate, data_.load(std::memory_order_relaxed))
+            .release(),
+        std::memory_order_release);
+  }
+  return cloned_table;
+}
+#endif
 
 int StringTable::Capacity() const {
   return data_.load(std::memory_order_acquire)->table().capacity();

--- a/src/objects/string-table.h
+++ b/src/objects/string-table.h
@@ -56,6 +56,10 @@ class V8_EXPORT_PRIVATE StringTable {
   explicit StringTable(Isolate* isolate);
   ~StringTable();
 
+#ifdef V8_COMPRESS_POINTERS_IN_MULTIPLE_CAGES
+  std::unique_ptr<StringTable> Clone(Isolate* isolate);
+#endif
+
   int Capacity() const;
   int NumberOfElements() const;
 


### PR DESCRIPTION
Introduce a cloning API for isolate groups and a corresponding API for materializing cloned isolates.

After cloning an isolate group, the isolates in the cloned group must be materialized before use. Materialization initializes all internal data structures of an isolate and prepares it for execution without modifying the already prepared memory from the cloned isolate group.